### PR TITLE
frontend: allow configuration of another webrtc server url

### DIFF
--- a/www/app/components/webrtc.js
+++ b/www/app/components/webrtc.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Peer from "simple-peer";
 
-const WebRTC_SERVER_URL = "http://127.0.0.1:1250/offer";
+const WEBRTC_SERVER_URL = process.env.NEXT_PUBLIC_WEBRTC_SERVER_URL || "http://127.0.0.1:1250/offer";
 
 const useWebRTC = (stream) => {
   const [data, setData] = useState({
@@ -17,7 +17,7 @@ const useWebRTC = (stream) => {
 
     peer.on("signal", (data) => {
       if ("sdp" in data) {
-        fetch(WebRTC_SERVER_URL, {
+        fetch(WEBRTC_SERVER_URL, {
           body: JSON.stringify({
             sdp: data.sdp,
             type: data.type,


### PR DESCRIPTION
Allow to point to another server instance than the default one.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

