### PR TITLE
Allow transcript summary edition

### DIFF
--- a/server/reflector/views/transcripts.py
+++ b/server/reflector/views/transcripts.py
@@ -190,6 +190,7 @@ class GetTranscript(BaseModel):
     status: str
     locked: bool
     duration: int
+    summary: str | None
     created_at: datetime
 
 
@@ -200,6 +201,7 @@ class CreateTranscript(BaseModel):
 class UpdateTranscript(BaseModel):
     name: Optional[str] = Field(None)
     locked: Optional[bool] = Field(None)
+    summary: Optional[str] = Field(None)
 
 
 class TranscriptEntryCreate(BaseModel):
@@ -262,6 +264,15 @@ async def transcript_update(
         values["name"] = info.name
     if info.locked is not None:
         values["locked"] = info.locked
+    if info.summary is not None:
+        values["summary"] = info.summary
+        # also find FINAL_SUMMARY event and patch it
+        for te in transcript.events:
+            if te["event"] == PipelineEvent.FINAL_SUMMARY:
+                te["summary"] = info.summary
+                break
+        values["events"] = transcript.events
+
     await transcripts_controller.update(transcript, values)
     return transcript
 

--- a/server/tests/test_transcripts.py
+++ b/server/tests/test_transcripts.py
@@ -45,6 +45,54 @@ async def test_transcript_get_update_name():
 
 
 @pytest.mark.asyncio
+async def test_transcript_get_update_locked():
+    from reflector.app import app
+
+    async with AsyncClient(app=app, base_url="http://test/v1") as ac:
+        response = await ac.post("/transcripts", json={"name": "test"})
+        assert response.status_code == 200
+        assert response.json()["locked"] is False
+
+        tid = response.json()["id"]
+
+        response = await ac.get(f"/transcripts/{tid}")
+        assert response.status_code == 200
+        assert response.json()["locked"] is False
+
+        response = await ac.patch(f"/transcripts/{tid}", json={"locked": True})
+        assert response.status_code == 200
+        assert response.json()["locked"] is True
+
+        response = await ac.get(f"/transcripts/{tid}")
+        assert response.status_code == 200
+        assert response.json()["locked"] is True
+
+
+@pytest.mark.asyncio
+async def test_transcript_get_update_summary():
+    from reflector.app import app
+
+    async with AsyncClient(app=app, base_url="http://test/v1") as ac:
+        response = await ac.post("/transcripts", json={"name": "test"})
+        assert response.status_code == 200
+        assert response.json()["summary"] is None
+
+        tid = response.json()["id"]
+
+        response = await ac.get(f"/transcripts/{tid}")
+        assert response.status_code == 200
+        assert response.json()["summary"] is None
+
+        response = await ac.patch(f"/transcripts/{tid}", json={"summary": "test"})
+        assert response.status_code == 200
+        assert response.json()["summary"] == "test"
+
+        response = await ac.get(f"/transcripts/{tid}")
+        assert response.status_code == 200
+        assert response.json()["summary"] == "test"
+
+
+@pytest.mark.asyncio
 async def test_transcripts_list_anonymous():
     # XXX this test is a bit fragile, as it depends on the storage which
     #     is shared between tests


### PR DESCRIPTION

## Allow transcript summary edition

Allow transcript summary edition, but do not restrict "when".
1. May it be preferable to allow edition only when the transcript is finished ?
2. What happen if the user continue recording ?

Closes #161

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [x] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

