### PR TITLE
Remove cache dir to use default download paths

### DIFF
--- a/server/reflector/llm/base.py
+++ b/server/reflector/llm/base.py
@@ -48,10 +48,9 @@ class LLM:
         Make sure NLTK package is installed. Searches in the cache and
         downloads only if needed.
         """
-        nltk.download("punkt", download_dir=settings.CACHE_DIR)
+        nltk.download("punkt")
         # For POS tagging
-        nltk.download("averaged_perceptron_tagger", download_dir=settings.CACHE_DIR)
-        nltk.data.path.append(settings.CACHE_DIR)
+        nltk.download("averaged_perceptron_tagger")
 
     @classmethod
     def register(cls, name, klass):


### PR DESCRIPTION
## ⚠️Using cache dir for NLTK seems to create a temp dir inside '/root/nltk' which is not desired. hence, falling back to default installation and load paths to prevent loading issue. ⚠️

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally


### Urgency

 - [x] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

