### PR TITLE
Remove isProjector env variable (since it's branch based) and removed forgotten console.log

### DIFF
--- a/www/app/lib/utils.ts
+++ b/www/app/lib/utils.ts
@@ -1,7 +1,3 @@
-export function isProjector() {
-  return process.env.NEXT_PUBLIC_PROJECTOR_MODE === "true";
-}
-
 export function isDevelopment() {
   return process.env.NEXT_PUBLIC_ENV === "development";
 }

--- a/www/app/transcripts/recorder.tsx
+++ b/www/app/transcripts/recorder.tsx
@@ -14,7 +14,6 @@ import { formatTime } from "../lib/time";
 import { Topic } from "./webSocketTypes";
 import { useError } from "../(errors)/errorContext";
 
-import { isProjector } from "../lib/utils";
 import { AudioWaveform } from "../api";
 
 const AudioInputsDropdown: React.FC<{
@@ -232,11 +231,7 @@ export default function Recorder(props: RecorderProps) {
   useEffect(() => {
     if (!record) return;
 
-    let cleanup: (() => void) | undefined;
-
-    if (isProjector()) {
-      cleanup = setupProjectorKeys();
-    }
+    const cleanup = setupProjectorKeys();
 
     return () => {
       record.on("stopRecording", () => {
@@ -307,7 +302,6 @@ export default function Recorder(props: RecorderProps) {
     if (duration) return `${formatTime(currentTime)}/${formatTime(duration)}`;
     return "";
   };
-  console.log(timeLabel);
 
   return (
     <div className="relative w-full">


### PR DESCRIPTION
## Remove isProjector env variable (since it's branch based) and removed forgotten console.log

Rationale:

Currently reflector projector is branch-based. There are plans for the future to make it an environment variables, but it is not currently the case. The environment variable-based reflector projector was partially implemented, causing keyboard shortcuts to not be enabled unless a certain env variable is set to a certain value. This has been removed.

### Checklist

 - [X] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [X] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [X] Non-urgent (deploying in next release is ok)

