### PR TITLE
Handle disconnection error

### DIFF
--- a/www/app/transcripts/new/page.tsx
+++ b/www/app/transcripts/new/page.tsx
@@ -16,6 +16,8 @@ import { faGear } from "@fortawesome/free-solid-svg-icons";
 import About from "../../(aboutAndPrivacy)/about";
 import Privacy from "../../(aboutAndPrivacy)/privacy";
 import { lockWakeState, releaseWakeState } from "../../lib/wakeLock";
+import { useError } from "../../(errors)/errorContext";
+import Link from "next/link";
 
 const TranscriptCreate = () => {
   const [stream, setStream] = useState<MediaStream | null>(null);
@@ -58,6 +60,15 @@ const TranscriptCreate = () => {
       releaseWakeState();
     };
   }, []);
+  const { error } = useError();
+  console.log(error);
+  const [hasErrored, setHasErrored] = useState(false);
+
+  useEffect(() => {
+    if (!hasErrored && error) {
+      setHasErrored(true);
+    }
+  }, [hasErrored, error]);
 
   return (
     <>
@@ -87,7 +98,22 @@ const TranscriptCreate = () => {
             <section
               className={`w-full h-full bg-blue-400/20 rounded-lg md:rounded-xl p-2 md:px-4`}
             >
-              {!hasRecorded ? (
+              {hasErrored ? (
+                <div className="flex flex-col justify-center align-center text-center h-full">
+                  <div>
+                    <p className="text-center text-gray-500 mb-3">
+                      An unfortunate error has occured and the transcription can
+                      not resume.
+                    </p>
+                    <Link
+                      className="bg-red-400 hover:bg-red-500 focus-visible:bg-red-500 text-white rounded p-2"
+                      href="/"
+                    >
+                      Try Again
+                    </Link>
+                  </div>
+                </div>
+              ) : !hasRecorded ? (
                 <>
                   {transcriptStarted && (
                     <h2 className="md:text-lg font-bold">Transcription</h2>


### PR DESCRIPTION
## Handle disconnection error

For now, this pr makes it that on receiving an error on the new page, we show a text to refresh the page. I think on this page, there can only be Websockets and WebRTC errors, I'll look into which ones we cannot recover from (yet) filter the errors.

![image](https://github.com/Monadical-SAS/reflector/assets/94755911/8245dc54-cfb0-4050-9ce2-6467a0ac9465)

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

