### PR TITLE
Fix permission detection system on firefox

### DIFF
--- a/www/app/transcripts/new/page.tsx
+++ b/www/app/transcripts/new/page.tsx
@@ -44,6 +44,7 @@ const TranscriptCreate = () => {
     requestPermission,
     getAudioStream,
   } = useAudioDevice();
+
   const [hasRecorded, setHasRecorded] = useState(false);
   const [transcriptStarted, setTranscriptStarted] = useState(false);
 

--- a/www/app/transcripts/recorder.tsx
+++ b/www/app/transcripts/recorder.tsx
@@ -57,7 +57,7 @@ export default function Recorder(props: RecorderProps) {
     const handleKeyPress = (event: KeyboardEvent) => {
       switch (event.key) {
         case "~":
-          location.href = ""
+          location.href = "";
           break;
         case ",":
           location.href = "/transcripts/new";

--- a/www/app/transcripts/useAudioDevice.ts
+++ b/www/app/transcripts/useAudioDevice.ts
@@ -21,6 +21,21 @@ const useAudioDevice = () => {
   }, [permissionOk]);
 
   const checkPermission = (): void => {
+    if (navigator.userAgent.includes("Firefox")) {
+      navigator.mediaDevices
+        .getUserMedia({ audio: true, video: false })
+        .then((stream) => {
+          setPermissionOk(true);
+          setPermissionDenied(false);
+        })
+        .catch((e) => {
+          setPermissionOk(false);
+          setPermissionDenied(false);
+        })
+        .finally(() => setLoading(false));
+      return;
+    }
+
     navigator.permissions
       .query(MIC_QUERY)
       .then((permissionStatus) => {


### PR DESCRIPTION
## Fix permission detection system on firefox

Firefox does things its own way and does not support navigator.permissions.query(MIC_QUERY)

### Checklist

 - [X] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [X] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [X] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

