### PR TITLE
www: fix webrtc not sending STOP command

### DIFF
--- a/www/app/transcripts/new/page.tsx
+++ b/www/app/transcripts/new/page.tsx
@@ -67,7 +67,7 @@ const TranscriptCreate = () => {
           <Recorder
             setStream={setStream}
             onStop={() => {
-              webRTC?.peer?.send(JSON.stringify({ cmd: "STOP" }));
+              webRTC?.send(JSON.stringify({ cmd: "STOP" }));
               setStream(null);
               setHasRecorded(true);
             }}


### PR DESCRIPTION
## fix webrtc not sending STOP command

The frontend was not sending STOP command anymore, and relying on connection closed to start flushing the pipeline. This was why it could take more time than expected on slow connection / conference.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [x] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

