### PR TITLE
Use websocket status "ended" for redirecting

### DIFF
--- a/www/app/transcripts/useWebSockets.ts
+++ b/www/app/transcripts/useWebSockets.ts
@@ -177,6 +177,16 @@ export const useWebSockets = (transcriptId: string | null): UseWebSockets => {
           case "FINAL_LONG_SUMMARY":
             if (message.data) {
               setFinalSummary(message.data);
+            }
+            break;
+
+          case "FINAL_TITLE":
+            console.debug("FINAL_TITLE event:", message.data);
+            break;
+
+          case "STATUS":
+            console.log("STATUS event:", message.data);
+            if (message.data.value === "ended") {
               const newUrl = "/transcripts/" + transcriptId;
               router.push(newUrl);
               console.debug(
@@ -186,13 +196,6 @@ export const useWebSockets = (transcriptId: string | null): UseWebSockets => {
                 newUrl,
               );
             }
-            break;
-
-          case "FINAL_TITLE":
-            console.debug("FINAL_TITLE event:", message.data);
-            break;
-
-          case "STATUS":
             setStatus(message.data);
             break;
 


### PR DESCRIPTION
## Use websocket status "ended" for redirecting

Currently we use the final summary event, but it does not mean the pipeline is actually finished.
Using websocket status ended indicate everything has correctly finished, and so we have all the information for final page.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

