### PR TITLE
Remove webm download button on the recording meeting page

### DIFF
--- a/www/app/transcripts/recorder.tsx
+++ b/www/app/transcripts/recorder.tsx
@@ -208,12 +208,6 @@ export default function Recorder(props: RecorderProps) {
     if (!record) return;
 
     return record.on("stopRecording", () => {
-      const link = document.getElementById("download-recording");
-      if (!link) return;
-
-      link.setAttribute("href", record.getRecordedUrl());
-      link.setAttribute("download", "reflector-recording.webm");
-      link.style.visibility = "visible";
       renderMarkers();
     });
   }, [record]);
@@ -318,16 +312,6 @@ export default function Recorder(props: RecorderProps) {
               title="Download recording"
               className="text-center cursor-pointer text-blue-400 hover:text-blue-700 ml-2 md:ml:4 p-2 rounded-lg outline-blue-400"
               href={`${process.env.NEXT_PUBLIC_API_URL}/v1/transcripts/${props.transcriptId}/audio/mp3`}
-            >
-              <FontAwesomeIcon icon={faDownload} className="h-5 w-auto" />
-            </a>
-          )}
-
-          {!props.transcriptId && (
-            <a
-              id="download-recording"
-              title="Download recording"
-              className="invisible text-center text-blue-400 hover:text-blue-700 ml-2 md:ml:4 p-2 rounded-lg outline-blue-400"
             >
               <FontAwesomeIcon icon={faDownload} className="h-5 w-auto" />
             </a>


### PR DESCRIPTION
## Remove webm download button on the recording meeting page

When we are finished recording, but not yet moved to the final page, the download button is the webm version. This has been replaced with mp3 url on final page, so this part is not necessary anymore.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

