### PR TITLE
Remove lang code conversion as front end sends it

### DIFF
--- a/server/gpu/modal/reflector_translator.py
+++ b/server/gpu/modal/reflector_translator.py
@@ -171,8 +171,8 @@ class Translator:
         translated_text, _, _ = self.translator.predict(
             text,
             "t2tt",
-            src_lang=self.get_seamless_lang_code(source_language),
-            tgt_lang=self.get_seamless_lang_code(target_language),
+            src_lang=source_language,
+            tgt_lang=target_language,
             ngram_filtering=True
         )
         return {


### PR DESCRIPTION
## ⚠️ Remove lang code conversion as front end sends it ⚠️

[LINK](https://github.com/facebookresearch/seamless_communication/tree/main/scripts/m4t/predict#supported-languages)
The language codes usually are only 2 characters like "en", "fr", etc.
But the seamless model lang codes are different -> "eng", "fra", etc.
So to ensure back compatibility, I use a function at the Modal app to convert "en", "fr" to their respective seamless lang codes. So, once UI changes are done to send the codes mentioned in the table, I can bypass this special function as it wont be needed anymore.

I am retaining the function though as a reference for back compatibility/reminder, if we decide to change the translation model.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

### Urgency

 - [x] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

