### PR TITLE
CD/CI: include only server when unit testing server

### DIFF
--- a/.github/workflows/test_server.yml
+++ b/.github/workflows/test_server.yml
@@ -2,11 +2,11 @@ name: Unittests
 
 on:
   pull_request:
-    paths-ignore:
-      - 'www/**'
+    paths:
+      - 'server/'
   push:
-    paths-ignore:
-      - 'www/**'
+    paths:
+      - 'server/'
 
 jobs:
   pytest:


### PR DESCRIPTION
This prevent the tests to run when readme is changed.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

