### PR TITLE
Add support for HEAD route on audio mp3

### DIFF
--- a/server/reflector/views/_range_requests_response.py
+++ b/server/reflector/views/_range_requests_response.py
@@ -1,7 +1,7 @@
 import os
 from typing import BinaryIO
 
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 
 
@@ -56,6 +56,9 @@ def range_requests_response(
             "content-range, content-encoding"
         ),
     }
+
+    if request.method == "HEAD":
+        return Response(headers=headers)
 
     if content_disposition:
         headers["Content-Disposition"] = content_disposition

--- a/server/reflector/views/transcripts.py
+++ b/server/reflector/views/transcripts.py
@@ -210,6 +210,7 @@ async def transcript_delete(
 
 
 @router.get("/transcripts/{transcript_id}/audio/mp3")
+@router.head("/transcripts/{transcript_id}/audio/mp3")
 async def transcript_get_audio_mp3(
     request: Request,
     transcript_id: str,

--- a/server/tests/test_transcripts_audio_download.py
+++ b/server/tests/test_transcripts_audio_download.py
@@ -46,6 +46,34 @@ async def test_transcript_audio_download(fake_transcript, url_suffix, content_ty
     assert response.status_code == 200
     assert response.headers["content-type"] == content_type
 
+    # test get 404
+    ac = AsyncClient(app=app, base_url="http://test/v1")
+    response = await ac.get(f"/transcripts/{fake_transcript.id}XXX/audio{url_suffix}")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url_suffix,content_type",
+    [
+        ["/mp3", "audio/mpeg"],
+    ],
+)
+async def test_transcript_audio_download_head(
+    fake_transcript, url_suffix, content_type
+):
+    from reflector.app import app
+
+    ac = AsyncClient(app=app, base_url="http://test/v1")
+    response = await ac.head(f"/transcripts/{fake_transcript.id}/audio{url_suffix}")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == content_type
+
+    # test head 404
+    ac = AsyncClient(app=app, base_url="http://test/v1")
+    response = await ac.head(f"/transcripts/{fake_transcript.id}XXX/audio{url_suffix}")
+    assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Add support for HEAD route on audio mp3

This allow to check first if a mp3 is available for download.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [x] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

