### PR TITLE
Fix slow profanity filter with a redis cache

### DIFF
--- a/server/reflector/redis_cache.py
+++ b/server/reflector/redis_cache.py
@@ -1,0 +1,50 @@
+import functools
+import json
+
+import redis
+from reflector.settings import settings
+
+redis_clients = {}
+
+
+def get_redis_client(db=0):
+    """
+    Get a Redis client for the specified database.
+    """
+    if db not in redis_clients:
+        redis_clients[db] = redis.StrictRedis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=db,
+        )
+    return redis_clients[db]
+
+
+def redis_cache(prefix="cache", duration=3600, db=settings.REDIS_CACHE_DB, argidx=1):
+    """
+    Cache the result of a function in Redis.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # Check if the first argument is a string
+            if len(args) < (argidx + 1) or not isinstance(args[argidx], str):
+                return func(*args, **kwargs)
+
+            # Compute the cache key based on the arguments and prefix
+            cache_key = prefix + ":" + args[argidx]
+            redis_client = get_redis_client(db=db)
+            cached_result = redis_client.get(cache_key)
+
+            if cached_result:
+                return json.loads(cached_result.decode("utf-8"))
+
+            # If the result is not cached, call the original function
+            result = func(*args, **kwargs)
+            redis_client.setex(cache_key, duration, json.dumps(result))
+            return result
+
+        return wrapper
+
+    return decorator

--- a/server/reflector/settings.py
+++ b/server/reflector/settings.py
@@ -124,6 +124,7 @@ class Settings(BaseSettings):
     # Redis
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379
+    REDIS_CACHE_DB: int = 2
 
     # Secret key
     SECRET_KEY: str = "changeme-f02f86fd8b3e4fd892c6043e5a298e21"


### PR DESCRIPTION
## Fix slow profanity filter with a redis cache

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

