### PR TITLE
Ability to deactivate diarization on the server

### DIFF
--- a/server/reflector/pipelines/main_live_pipeline.py
+++ b/server/reflector/pipelines/main_live_pipeline.py
@@ -263,11 +263,7 @@ class PipelineMainLive(PipelineMainBase):
             TranscriptLinerProcessor(),
             TranscriptTranslatorProcessor.as_threaded(callback=self.on_transcript),
             TranscriptTopicDetectorProcessor.as_threaded(callback=self.on_topic),
-            BroadcastProcessor(
-                processors=[
-                    TranscriptFinalTitleProcessor.as_threaded(callback=self.on_title),
-                ]
-            ),
+            TranscriptFinalTitleProcessor.as_threaded(callback=self.on_title),
         ]
         pipeline = Pipeline(*processors)
         pipeline.options = self
@@ -298,8 +294,13 @@ class PipelineMainDiarization(PipelineMainBase):
         # create a context for the whole rtc transaction
         # add a customised logger to the context
         self.prepare()
-        processors = [
-            AudioDiarizationAutoProcessor(callback=self.on_topic),
+        processors = []
+        if settings.DIARIZATION_ENABLED:
+            processors += [
+                AudioDiarizationAutoProcessor(callback=self.on_topic),
+            ]
+
+        processors += [
             BroadcastProcessor(
                 processors=[
                     TranscriptFinalLongSummaryProcessor.as_threaded(

--- a/server/reflector/settings.py
+++ b/server/reflector/settings.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     LLM_MODAL_API_KEY: str | None = None
 
     # Diarization
+    DIARIZATION_ENABLED: bool = True
     DIARIZATION_BACKEND: str = "modal"
     DIARIZATION_URL: str | None = None
 


### PR DESCRIPTION
## Ability to deactivate diarization on the server

The current work of diarization is not possible to run on local server, except if the server is accessible from the internet.
By settings `DIARIZATION_ENABLED=false`, it will avoid to run the diarization.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

