### PR TITLE
Speaker Names Have Better Contrast (but less variety)

### DIFF
--- a/www/app/lib/utils.ts
+++ b/www/app/lib/utils.ts
@@ -98,26 +98,31 @@ export function murmurhash3_32_gc(key: string, seed: number = 0) {
 
 export const generateHighContrastColor = (
   name: string,
-  backgroundColor: [number, number, number] | null = null,
+  backgroundColor: [number, number, number],
 ) => {
-  const hash = murmurhash3_32_gc(name);
-  let red = (hash & 0xff0000) >> 16;
-  let green = (hash & 0x00ff00) >> 8;
-  let blue = hash & 0x0000ff;
+  let loopNumber = 0;
+  let minAcceptedContrast = 3.5;
+  while (true && /* Just as a safeguard */ loopNumber < 100) {
+    ++loopNumber;
 
-  const getCssColor = (red: number, green: number, blue: number) =>
-    `rgb(${red}, ${green}, ${blue})`;
+    if (loopNumber > 5) minAcceptedContrast -= 0.5;
 
-  if (!backgroundColor) return getCssColor(red, green, blue);
+    const hash = murmurhash3_32_gc(name + loopNumber);
+    let red = (hash & 0xff0000) >> 16;
+    let green = (hash & 0x00ff00) >> 8;
+    let blue = hash & 0x0000ff;
 
-  const contrast = getContrastRatio([red, green, blue], backgroundColor);
+    let contrast = getContrastRatio([red, green, blue], backgroundColor);
 
-  // Adjust the color to achieve better contrast if necessary (WCAG recommends at least 4.5:1 for text)
-  if (contrast < 4.5) {
+    if (contrast > minAcceptedContrast) return `rgb(${red}, ${green}, ${blue})`;
+
+    // Try to invert the color to increase contrat - this works best the more away the color is from gray
     red = Math.abs(255 - red);
     green = Math.abs(255 - green);
     blue = Math.abs(255 - blue);
-  }
 
-  return getCssColor(red, green, blue);
+    contrast = getContrastRatio([red, green, blue], backgroundColor);
+
+    if (contrast > minAcceptedContrast) return `rgb(${red}, ${green}, ${blue})`;
+  }
 };


### PR DESCRIPTION
## Speaker Names Have Better Contrast (but less variety)

![Screenshot 2023-11-30 at 9 28 24 PM](https://github.com/Monadical-SAS/reflector/assets/78463782/20b93988-bd94-4a99-93b5-33a57ac890cc)


- Goes over a loop up to 50 times
- Creates a random color
- Checks if the accepted contrast is enough, if it's not it tries to invert the color and see if that is enough, if neither are enough it will continue do another iteration, if either is enough it will return
- From the 6th loop iteration the minimum accepted contrast loses 0.5 points
- Eventually a color is found

### Checklist

 - [X] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [X] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [X] Non-urgent (deploying in next release is ok)

