### PR TITLE
server: fix openapi generation with duplicate route for audio/mp3

### DIFF
--- a/server/reflector/app.py
+++ b/server/reflector/app.py
@@ -100,7 +100,10 @@ def use_route_names_as_operation_ids(app: FastAPI) -> None:
             version = None
             if route.path.startswith("/v"):
                 version = route.path.split("/")[1]
-                opid = f"{version}_{route.name}"
+                if route.operation_id is not None:
+                    opid = f"{version}_{route.operation_id}"
+                else:
+                    opid = f"{version}_{route.name}"
             else:
                 opid = route.name
 
@@ -110,7 +113,7 @@ def use_route_names_as_operation_ids(app: FastAPI) -> None:
                     "Please rename the route or the view function."
                 )
             route.operation_id = opid
-            ensure_uniq_operation_ids.add(route.name)
+            ensure_uniq_operation_ids.add(opid)
 
 
 use_route_names_as_operation_ids(app)

--- a/server/reflector/views/transcripts_audio.py
+++ b/server/reflector/views/transcripts_audio.py
@@ -18,8 +18,14 @@ from ._range_requests_response import range_requests_response
 router = APIRouter()
 
 
-@router.get("/transcripts/{transcript_id}/audio/mp3")
-@router.head("/transcripts/{transcript_id}/audio/mp3")
+@router.get(
+    "/transcripts/{transcript_id}/audio/mp3",
+    operation_id="transcript_get_audio_mp3",
+)
+@router.head(
+    "/transcripts/{transcript_id}/audio/mp3",
+    operation_id="transcript_head_audio_mp3",
+)
 async def transcript_get_audio_mp3(
     request: Request,
     transcript_id: str,

--- a/www/app/api/apis/DefaultApi.ts
+++ b/www/app/api/apis/DefaultApi.ts
@@ -121,6 +121,11 @@ export interface V1TranscriptGetWebsocketEventsRequest {
   transcriptId: any;
 }
 
+export interface V1TranscriptHeadAudioMp3Request {
+  transcriptId: any;
+  token?: any;
+}
+
 export interface V1TranscriptMergeSpeakerRequest {
   transcriptId: any;
   speakerMerge: SpeakerMerge;
@@ -1058,6 +1063,73 @@ export class DefaultApi extends runtime.BaseAPI {
     initOverrides?: RequestInit | runtime.InitOverrideFunction,
   ): Promise<any> {
     const response = await this.v1TranscriptGetWebsocketEventsRaw(
+      requestParameters,
+      initOverrides,
+    );
+    return await response.value();
+  }
+
+  /**
+   * Transcript Get Audio Mp3
+   */
+  async v1TranscriptHeadAudioMp3Raw(
+    requestParameters: V1TranscriptHeadAudioMp3Request,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<runtime.ApiResponse<any>> {
+    if (
+      requestParameters.transcriptId === null ||
+      requestParameters.transcriptId === undefined
+    ) {
+      throw new runtime.RequiredError(
+        "transcriptId",
+        "Required parameter requestParameters.transcriptId was null or undefined when calling v1TranscriptHeadAudioMp3.",
+      );
+    }
+
+    const queryParameters: any = {};
+
+    if (requestParameters.token !== undefined) {
+      queryParameters["token"] = requestParameters.token;
+    }
+
+    const headerParameters: runtime.HTTPHeaders = {};
+
+    if (this.configuration && this.configuration.accessToken) {
+      // oauth required
+      headerParameters["Authorization"] = await this.configuration.accessToken(
+        "OAuth2AuthorizationCodeBearer",
+        [],
+      );
+    }
+
+    const response = await this.request(
+      {
+        path: `/v1/transcripts/{transcript_id}/audio/mp3`.replace(
+          `{${"transcript_id"}}`,
+          encodeURIComponent(String(requestParameters.transcriptId)),
+        ),
+        method: "HEAD",
+        headers: headerParameters,
+        query: queryParameters,
+      },
+      initOverrides,
+    );
+
+    if (this.isJsonMime(response.headers.get("content-type"))) {
+      return new runtime.JSONApiResponse<any>(response);
+    } else {
+      return new runtime.TextApiResponse(response) as any;
+    }
+  }
+
+  /**
+   * Transcript Get Audio Mp3
+   */
+  async v1TranscriptHeadAudioMp3(
+    requestParameters: V1TranscriptHeadAudioMp3Request,
+    initOverrides?: RequestInit | runtime.InitOverrideFunction,
+  ): Promise<any> {
+    const response = await this.v1TranscriptHeadAudioMp3Raw(
       requestParameters,
       initOverrides,
     );

--- a/www/app/api/models/GetTranscript.ts
+++ b/www/app/api/models/GetTranscript.ts
@@ -103,6 +103,12 @@ export interface GetTranscript {
    * @memberof GetTranscript
    */
   participants: any | null;
+  /**
+   *
+   * @type {any}
+   * @memberof GetTranscript
+   */
+  reviewed: any | null;
 }
 
 /**
@@ -123,6 +129,7 @@ export function instanceOfGetTranscript(value: object): boolean {
   isInstance = isInstance && "sourceLanguage" in value;
   isInstance = isInstance && "targetLanguage" in value;
   isInstance = isInstance && "participants" in value;
+  isInstance = isInstance && "reviewed" in value;
 
   return isInstance;
 }
@@ -153,6 +160,7 @@ export function GetTranscriptFromJSONTyped(
     sourceLanguage: json["source_language"],
     targetLanguage: json["target_language"],
     participants: json["participants"],
+    reviewed: json["reviewed"],
   };
 }
 
@@ -178,5 +186,6 @@ export function GetTranscriptToJSON(value?: GetTranscript | null): any {
     source_language: value.sourceLanguage,
     target_language: value.targetLanguage,
     participants: value.participants,
+    reviewed: value.reviewed,
   };
 }

--- a/www/app/api/models/UpdateTranscript.ts
+++ b/www/app/api/models/UpdateTranscript.ts
@@ -61,6 +61,12 @@ export interface UpdateTranscript {
    * @memberof UpdateTranscript
    */
   participants?: any | null;
+  /**
+   *
+   * @type {any}
+   * @memberof UpdateTranscript
+   */
+  reviewed?: any | null;
 }
 
 /**
@@ -97,6 +103,7 @@ export function UpdateTranscriptFromJSONTyped(
     participants: !exists(json, "participants")
       ? undefined
       : json["participants"],
+    reviewed: !exists(json, "reviewed") ? undefined : json["reviewed"],
   };
 }
 
@@ -115,5 +122,6 @@ export function UpdateTranscriptToJSON(value?: UpdateTranscript | null): any {
     long_summary: value.longSummary,
     share_mode: value.shareMode,
     participants: value.participants,
+    reviewed: value.reviewed,
   };
 }


### PR DESCRIPTION
## Fix openapi generation with duplicate route for audio/mp3

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

