### PR TITLE
Reduce transactions sent to sentry

### DIFF
--- a/server/reflector/app.py
+++ b/server/reflector/app.py
@@ -45,7 +45,7 @@ if settings.SENTRY_DSN:
         logger.error("Sentry is not installed, avoided")
     else:
         logger.info("Sentry enabled")
-    sentry_sdk.init(dsn=settings.SENTRY_DSN)
+    sentry_sdk.init(dsn=settings.SENTRY_DSN, traces_sample_rate=0.01)
 else:
     logger.info("Sentry disabled")
 


### PR DESCRIPTION
##  Reduce transactions sent to sentry

Looks like not providing traces_sample_rate value defaults to sending all transactions to sentry:
https://monadical.sentry.io/stats/?dataCategory=transactions&project=4505634564145152&statsPeriod=30d

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

