### PR TITLE
fix: ignore celery beat schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ server/exportdanswer
 .vercel
 .env*.local
 dump.rdb
+server/celerybeat-schedule


### PR DESCRIPTION
## Ignore celery beat schedule

This file is generated by celery beat, but should not be committed.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [x] Non-urgent (deploying in next release is ok)

