### PR TITLE
fix: user migration confusion with user_id

### DIFF
--- a/server/reflector/db/migrate_user.py
+++ b/server/reflector/db/migrate_user.py
@@ -31,20 +31,26 @@ async def migrate_user(email, user_id):
     if not user_ids:
         return
 
-    for user_id in user_ids:
+    # do not migrate back
+    if user_id in user_ids:
+        return
+
+    for old_user_id in user_ids:
         query = (
             transcripts.update()
-            .where(transcripts.c.user_id == user_id)
+            .where(transcripts.c.user_id == old_user_id)
             .values(user_id=user_id)
         )
         await database.execute(query)
 
-        query = rooms.update().where(rooms.c.user_id == user_id).values(user_id=user_id)
+        query = (
+            rooms.update().where(rooms.c.user_id == old_user_id).values(user_id=user_id)
+        )
         await database.execute(query)
 
         query = (
             meetings.update()
-            .where(meetings.c.user_id == user_id)
+            .where(meetings.c.user_id == old_user_id)
             .values(user_id=user_id)
         )
         await database.execute(query)


### PR DESCRIPTION
## fix: user migration confusion with user_id

There was a confusion in the migrate_user function with user_id as argument and in the loop. Which make the user migration failing.

### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

