### PR TITLE
fix: prevent unattended reloading on transcript page

### DIFF
--- a/www/app/(app)/transcripts/useMp3.ts
+++ b/www/app/(app)/transcripts/useMp3.ts
@@ -52,7 +52,7 @@ const useMp3 = (id: string, waiting?: boolean): Mp3Response => {
     audioElement.preload = "auto";
     setMedia(audioElement);
     setLoading(false);
-  }, [id, api, later]);
+  }, [id, !api, later]);
 
   const getNow = () => {
     setLater(false);

--- a/www/app/(app)/transcripts/useTopics.ts
+++ b/www/app/(app)/transcripts/useTopics.ts
@@ -38,7 +38,7 @@ const useTopics = (id: string): TranscriptTopics => {
           setError(err);
         }
       });
-  }, [id, api]);
+  }, [id, !api]);
 
   return { topics, loading, error };
 };

--- a/www/app/(app)/transcripts/useWaveform.ts
+++ b/www/app/(app)/transcripts/useWaveform.ts
@@ -36,7 +36,7 @@ const useWaveform = (id: string, waiting: boolean): AudioWaveFormResponse => {
           setError(err);
         }
       });
-  }, [id, api, waiting]);
+  }, [id, !api, waiting]);
 
   return { waveform, loading, error };
 };

--- a/www/app/(app)/transcripts/useWebRTC.ts
+++ b/www/app/(app)/transcripts/useWebRTC.ts
@@ -13,7 +13,7 @@ const useWebRTC = (
   const api = useApi();
 
   useEffect(() => {
-    if (!stream || !transcriptId) {
+    if (!stream || !transcriptId || !api) {
       return;
     }
 
@@ -63,7 +63,7 @@ const useWebRTC = (
     return () => {
       p.destroy();
     };
-  }, [stream, transcriptId]);
+  }, [stream, transcriptId, !api]);
 
   return peer;
 };


### PR DESCRIPTION
## fix: prevent unattended reloading on transcript page

When reading a reflector final summary, i was still having some auto reloading; It was due to some `useEffect()` that was using `api` and not the trick `!api`

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

