### PR TITLE
Enable local recording

### DIFF
--- a/www/app/(app)/rooms/page.tsx
+++ b/www/app/(app)/rooms/page.tsx
@@ -56,6 +56,12 @@ const recordingTriggerOptions: Options<SelectOption> = [
   { label: "Automatic", value: "automatic-2nd-participant" },
 ];
 
+const recordingTypeOptions: Options<SelectOption> = [
+  { label: "None", value: "none" },
+  { label: "Local", value: "local" },
+  { label: "Cloud", value: "cloud" },
+];
+
 const roomInitialState = {
   name: "",
   zulipAutoPost: false,
@@ -187,7 +193,7 @@ export default function RoomsList() {
         (err.body as any).detail == "Room name is not unique"
       ) {
         setNameError(
-          "This room name is already taken. Please choose a different name.",
+          "This room name is already taken. Please choose a different name."
         );
       } else {
         setNameError("An error occurred. Please try again.");
@@ -310,7 +316,7 @@ export default function RoomsList() {
                     options={roomModeOptions}
                     value={{
                       label: roomModeOptions.find(
-                        (rm) => rm.value === room.roomMode,
+                        (rm) => rm.value === room.roomMode
                       )?.label,
                       value: room.roomMode,
                     }}
@@ -323,13 +329,36 @@ export default function RoomsList() {
                   />
                 </FormControl>
                 <FormControl mt={4}>
-                  <FormLabel>Recording start trigger</FormLabel>
+                  <FormLabel>Recording type</FormLabel>
+                  <Select
+                    name="recordingType"
+                    options={recordingTypeOptions}
+                    value={{
+                      label: recordingTypeOptions.find(
+                        (rt) => rt.value === room.recordingType
+                      )?.label,
+                      value: room.recordingType,
+                    }}
+                    onChange={(newValue) =>
+                      setRoom({
+                        ...room,
+                        recordingType: newValue!.value,
+                        recordingTrigger:
+                          newValue!.value !== "cloud"
+                            ? "none"
+                            : room.recordingTrigger,
+                      })
+                    }
+                  />
+                </FormControl>
+                <FormControl mt={4}>
+                  <FormLabel>Cloud recording start trigger</FormLabel>
                   <Select
                     name="recordingTrigger"
                     options={recordingTriggerOptions}
                     value={{
                       label: recordingTriggerOptions.find(
-                        (rt) => rt.value === room.recordingTrigger,
+                        (rt) => rt.value === room.recordingTrigger
                       )?.label,
                       value: room.recordingTrigger,
                     }}
@@ -339,6 +368,7 @@ export default function RoomsList() {
                         recordingTrigger: newValue!.value,
                       })
                     }
+                    isDisabled={room.recordingType !== "cloud"}
                   />
                 </FormControl>
                 <FormControl mt={8}>


### PR DESCRIPTION
### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [x] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [x] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce an option for local recording in the room settings and adjust the logic for recording type selection and trigger configuration.

### Why are these changes being made?

To provide users with the flexibility to choose between local, cloud, or no recording options for meetings, enabling better control over recording preferences, especially in contexts where cloud storage might not be necessary or desired. The changes also ensure that trigger configuration is disabled if the recording type is set to local, aligning with the expected behavior that only cloud recordings need a trigger.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->