### PR TITLE
Remove is active check

### DIFF
--- a/server/reflector/db/meetings.py
+++ b/server/reflector/db/meetings.py
@@ -124,7 +124,6 @@ class MeetingController:
             .where(
                 sa.and_(
                     meetings.c.room_id == room.id,
-                    meetings.c.is_active,
                     meetings.c.end_date > current_time,
                 )
             )


### PR DESCRIPTION
### Checklist

 - [x] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [x] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the `is_active` check from the query condition in the `get_active` method of `meetings.py`.

### Why are these changes being made?

The `is_active` check was redundant for retrieving ongoing meetings as the `end_date > current_time` condition sufficiently determines active meetings. This simplification reduces complexity without affecting functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->