### PR TITLE
fix: display timestamps in user local timezone instead of UTC

### DIFF
--- a/server/reflector/db/transcripts.py
+++ b/server/reflector/db/transcripts.py
@@ -3,7 +3,7 @@ import json
 import os
 import shutil
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 from reflector.utils import generate_uuid4
@@ -78,7 +78,7 @@ transcripts = sqlalchemy.Table(
 
 
 def generate_transcript_name() -> str:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return f"Transcript {now.strftime('%Y-%m-%d %H:%M:%S')}"
 
 
@@ -146,7 +146,7 @@ class Transcript(BaseModel):
     status: str = "idle"
     locked: bool = False
     duration: float = 0
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     title: str | None = None
     short_summary: str | None = None
     long_summary: str | None = None

--- a/server/reflector/views/meetings.py
+++ b/server/reflector/views/meetings.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated, Optional
 
 import reflector.auth as auth
@@ -35,7 +35,7 @@ async def meeting_audio_consent(
         meeting_id=meeting_id,
         user_id=user_id,
         consent_given=request.consent_given,
-        consent_timestamp=datetime.utcnow(),
+        consent_timestamp=datetime.now(timezone.utc),
     )
 
     updated_consent = await meeting_consent_controller.upsert(consent)

--- a/server/reflector/views/rooms.py
+++ b/server/reflector/views/rooms.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from typing import Annotated, Optional, Literal
 
 import reflector.auth as auth
@@ -144,7 +144,7 @@ async def rooms_create_meeting(
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    current_time = datetime.utcnow()
+    current_time = datetime.now(timezone.utc)
     meeting = await meetings_controller.get_active(room=room, current_time=current_time)
 
     if meeting is None:

--- a/server/reflector/views/transcripts.py
+++ b/server/reflector/views/transcripts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, Literal, Optional
 
 import reflector.auth as auth
@@ -34,7 +34,7 @@ DOWNLOAD_EXPIRE_MINUTES = 60
 
 def create_access_token(data: dict, expires_delta: timedelta):
     to_encode = data.copy()
-    expire = datetime.utcnow() + expires_delta
+    expire = datetime.now(timezone.utc) + expires_delta
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/server/reflector/worker/process.py
+++ b/server/reflector/worker/process.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import unquote
 
 import av
@@ -139,7 +139,7 @@ async def process_meetings():
     meetings = await meetings_controller.get_all_active()
     for meeting in meetings:
         is_active = False
-        if meeting.end_date > datetime.utcnow():
+        if meeting.end_date > datetime.now(timezone.utc):
             response = await get_room_sessions(meeting.room_name)
             room_sessions = response.get("results", [])
             is_active = not room_sessions or any(

--- a/www/app/(app)/browse/page.tsx
+++ b/www/app/(app)/browse/page.tsx
@@ -46,7 +46,7 @@ import useSessionUser from "../../lib/useSessionUser";
 import NextLink from "next/link";
 import { Room, GetTranscript } from "../../api";
 import Pagination from "./pagination";
-import { formatTimeMs } from "../../lib/time";
+import { formatTimeMs, formatLocalDateTime } from "../../lib/time";
 import useApi from "../../lib/useApi";
 import { useError } from "../../(errors)/errorContext";
 import { SourceKind } from "../../api";
@@ -382,13 +382,7 @@ export default function TranscriptBrowser() {
                         : item.source_kind}
                     </Td>
                     <Td>
-                      {new Date(item.created_at).toLocaleString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                        hour: "numeric",
-                        minute: "numeric",
-                      })}
+                      {formatLocalDateTime(item.created_at)}
                     </Td>
                     <Td>{formatTimeMs(item.duration)}</Td>
                     <Td>
@@ -467,7 +461,7 @@ export default function TranscriptBrowser() {
                           : item.source_kind}
                       </Text>
                       <Text>
-                        Date: {new Date(item.created_at).toLocaleString()}
+                        Date: {formatLocalDateTime(item.created_at)}
                       </Text>
                       <Text>Duration: {formatTimeMs(item.duration)}</Text>
                     </Box>

--- a/www/app/lib/time.ts
+++ b/www/app/lib/time.ts
@@ -28,3 +28,22 @@ export const formatTimeDifference = (seconds: number): string => {
 
   return timeString;
 };
+
+export const parseUTCDate = (dateString: string): Date => {
+  if (dateString.endsWith('Z') || dateString.includes('+')) {
+    return new Date(dateString);
+  }
+  return new Date(dateString + 'Z');
+};
+
+export const formatLocalDateTime = (dateString: string, options?: Intl.DateTimeFormatOptions): string => {
+  const date = parseUTCDate(dateString);
+  const defaultOptions: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long", 
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  };
+  return date.toLocaleString("en-US", { ...defaultOptions, ...options });
+};


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes the timezone display issue in the browse page where timestamps were showing in UTC instead of the user's local timezone. The fix ensures proper timezone handling across both server and client sides.

## Changes Made

- **Server-side improvements**: Updated all `datetime.utcnow()` calls to use timezone-aware `datetime.now(timezone.utc)` for proper UTC serialization
- **Client-side utilities**: Added `parseUTCDate` and `formatLocalDateTime` functions to handle timezone conversion
- **Browse page updates**: Replaced naive date parsing with timezone-aware formatting in both desktop and mobile views
- **Consistent timezone handling**: Ensured UTC datetimes are properly serialized with timezone information

## Key Areas for Review

- `www/app/lib/time.ts` - New timezone utility functions
- `www/app/(app)/browse/page.tsx` - Updated date display logic
- Server datetime handling across multiple modules

Fixes #474

🤖 Generated with [opencode](https://opencode.ai)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix timezone display in browse page

- Add timezone-aware date utilities

- Update server datetime handling

- Ensure consistent UTC serialization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transcripts.py</strong><dd><code>Use timezone-aware UTC datetimes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/db/transcripts.py

<li>Updated imports to include timezone module<br> <li> Changed <code>datetime.utcnow()</code> to timezone-aware <code>datetime.now(timezone.utc)</code><br> <li> Modified <code>created_at</code> field default factory to use timezone-aware UTC <br>datetime


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-cb4fc52fe1297f4d5ccfeb99d710212805f36eafa816e0472b19a8d8d8bc6151">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>meetings.py</strong><dd><code>Update meeting consent timestamp to use timezone-aware UTC</code></dd></summary>
<hr>

server/reflector/views/meetings.py

<li>Updated imports to include timezone module<br> <li> Changed <code>datetime.utcnow()</code> to timezone-aware <code>datetime.now(timezone.utc)</code> <br>for consent timestamp


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-7e3fd97e1b2db692ad3f20ab84d8bb1f481e5a31da623272e1b826386b253712">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rooms.py</strong><dd><code>Use timezone-aware UTC for room operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/rooms.py

<li>Updated imports to include timezone module<br> <li> Changed <code>datetime.utcnow()</code> to timezone-aware <code>datetime.now(timezone.utc)</code> <br>for current_time


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-f4f3fba07cab0004d948ecb2a506ae0c27418cc030b22d433f99acd40be8eb63">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transcripts.py</strong><dd><code>Fix token expiration to use timezone-aware UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/transcripts.py

<li>Updated imports to include timezone module<br> <li> Changed <code>datetime.utcnow()</code> to timezone-aware <code>datetime.now(timezone.utc)</code> <br>for token expiration


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-403f4714db2253ef651c42aeed2643ad19d2066f061cbc0ba389064421c5d81b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>process.py</strong><dd><code>Update meeting processing to use timezone-aware UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/worker/process.py

<li>Updated imports to include timezone module<br> <li> Changed <code>datetime.utcnow()</code> to timezone-aware <code>datetime.now(timezone.utc)</code> <br>for meeting date comparison


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-68019eddc4079e7b8930374204c5fe955c3ee56cd7044ea12014af50cbc31771">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Replace naive date parsing with timezone-aware formatting</code></dd></summary>
<hr>

www/app/(app)/browse/page.tsx

<li>Imported new <code>formatLocalDateTime</code> function from time utilities<br> <li> Replaced direct <code>new Date().toLocaleString()</code> calls with <br><code>formatLocalDateTime()</code><br> <li> Fixed timestamp display in both desktop and mobile views


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-75a0ef795caf7db5242908e2f30288fed993865ad925fe998212ccd49125ded6">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>time.ts</strong><dd><code>Add timezone utility functions for date handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/lib/time.ts

<li>Added <code>parseUTCDate()</code> function to properly handle UTC date strings<br> <li> Added <code>formatLocalDateTime()</code> function to format dates in user's local <br>timezone<br> <li> Implemented timezone detection and proper conversion logic


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/478/files#diff-1bac909b8d25fdf35088846200b31d1f96dfd4b11c7c486a76fbd8b3310feb5e">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>