### PR TITLE
fix: resolve share mode change blocking and participant loading errors

### DIFF
--- a/server/reflector/db/transcripts.py
+++ b/server/reflector/db/transcripts.py
@@ -510,7 +510,7 @@ class TranscriptController:
         """
         A context manager for database transaction
         """
-        async with database.transaction(isolation="serializable"):
+        async with database.transaction():
             yield
 
     async def append_event(


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes the critical bug where share mode changes from "Public" to "Secure" would block the application and cause participant loading errors. The issue was caused by overly restrictive database transaction isolation levels and missing error handling in the frontend.

## Changes Made

- **Database Transaction Fix**: Removed `serializable` isolation level from SQLite transactions in `transcripts.py` to prevent unnecessary blocking during concurrent operations
- **Frontend Error Handling**: Added comprehensive try-catch-finally error handling to the share mode update function in `shareAndPrivacy.tsx` to ensure loading states are properly managed
- **Request Cancellation**: Implemented proper request cancellation in `useParticipants.ts` hook to prevent race conditions when share mode changes affect access permissions
- **Loading State Management**: Ensured that loading indicators are properly cleared even when errors occur

## Key Areas for Review

- **Database Transaction Changes**: Review the removal of serializable isolation level and its impact on data consistency
- **Error Handling Pattern**: Verify that the error handling follows the established patterns in the codebase
- **Request Cancellation Logic**: Ensure the cancellation mechanism properly handles cleanup and prevents memory leaks

## Testing

The changes address the specific issues mentioned in the bug report:
- Share mode changes no longer block subsequent API requests
- Participant loading works correctly during and after share mode transitions
- UI loading states are properly managed and cleared
- Error messages are displayed to users when operations fail

Fixes #477

🤖 Generated with [opencode](https://opencode.ai)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed database transaction blocking issue

- Added proper error handling in frontend

- Implemented request cancellation for participants

- Ensured loading states clear on errors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transcripts.py</strong><dd><code>Remove serializable isolation to prevent DB blocking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/db/transcripts.py

<li>Removed <code>isolation="serializable"</code> parameter from database transaction <br>to prevent blocking during concurrent operations


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/479/files#diff-cb4fc52fe1297f4d5ccfeb99d710212805f36eafa816e0472b19a8d8d8bc6151">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useParticipants.ts</strong><dd><code>Implement request cancellation in participants hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/useParticipants.ts

<li>Added useRef to track and manage cancelable promises<br> <li> Implemented request cancellation logic to prevent race conditions<br> <li> Added cleanup on component unmount and refetch<br> <li> Added special handling for CancelError to avoid showing errors for <br>canceled requests


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/479/files#diff-bf3e4dd1ab02ec26c76da8abfd8e9abaebdc41ca2fdcd4dcd08ad178dbee339e">+22/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shareAndPrivacy.tsx</strong><dd><code>Add robust error handling to share mode updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/shareAndPrivacy.tsx

<li>Added error handling context imports<br> <li> Implemented try-catch-finally pattern in updateShareMode function<br> <li> Added proper error state management and user feedback<br> <li> Ensured loading state is cleared even when errors occur


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/479/files#diff-b51146fc1d6569f6bf1692fe71080f2cef3489e24fb447b6cca091056176227e">+26/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>