### PR TITLE
fix: pre-download nltk packages to prevent runtime not working

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,10 +16,14 @@ WORKDIR /app
 COPY pyproject.toml uv.lock /app/
 RUN touch README.md && env uv sync --compile-bytecode --locked
 
+# pre-download nltk packages
+RUN uv run python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger')"
+
 # bootstrap
 COPY alembic.ini runserver.sh /app/
 COPY images /app/images
 COPY migrations /app/migrations
 COPY reflector /app/reflector
 WORKDIR /app
+
 CMD ["./runserver.sh"]

--- a/server/reflector/llm/base.py
+++ b/server/reflector/llm/base.py
@@ -45,7 +45,7 @@ class LLM:
         downloads only if needed.
         """
         if not cls._nltk_downloaded:
-            nltk.download("punkt")
+            nltk.download("punkt_tab")
             # For POS tagging
             nltk.download("averaged_perceptron_tagger")
             cls._nltk_downloaded = True
@@ -222,7 +222,7 @@ class LLM:
             title = modified_title[0].upper() + modified_title[1:]
         except Exception as e:
             reflector_logger.info(
-                f"Failed to ensure casing on {title=} " f"with exception : {str(e)}"
+                f"Failed to ensure casing on {title=} with exception : {str(e)}"
             )
 
         return title
@@ -245,9 +245,7 @@ class LLM:
             )
             title = re.sub(pattern, "", title, flags=re.IGNORECASE)
         except Exception as e:
-            reflector_logger.info(
-                f"Failed to trim {title=} " f"with exception : {str(e)}"
-            )
+            reflector_logger.info(f"Failed to trim {title=} with exception : {str(e)}")
         return title
 
     async def _generate(


### PR DESCRIPTION
### **User description**
## fix: pre-download nltk packages to prevent runtime not working

Got that on a deployment in reflector.media:

```
stacks-reflector-1         | **********************************************************************
stacks-reflector-1         |   Resource [93mpunkt_tab[0m not found.
stacks-reflector-1         |   Please use the NLTK Downloader to obtain the resource:
stacks-reflector-1         |
stacks-reflector-1         |
stacks-reflector-1         |   [31m>>> import nltk
stacks-reflector-1         |   >>> nltk.download('punkt_tab')
stacks-reflector-1         |   [0m
stacks-reflector-1         |   For more information see: https://www.nltk.org/data.html
stacks-reflector-1         |
stacks-reflector-1         |
stacks-reflector-1         |   Attempted to load [93mtokenizers/punkt_tab/english/[0m
stacks-reflector-1         |
stacks-reflector-1         |
stacks-reflector-1         |   Searched in:
stacks-reflector-1         |     - '/root/nltk_data'
stacks-reflector-1         |     - '/app/.venv/nltk_data'
stacks-reflector-1         |     - '/app/.venv/share/nltk_data'
stacks-reflector-1         |     - '/app/.venv/lib/nltk_data'
stacks-reflector-1         |     - '/usr/share/nltk_data'
stacks-reflector-1         |     - '/usr/local/share/nltk_data'
stacks-reflector-1         |     - '/usr/lib/nltk_data'
stacks-reflector-1         |     - '/usr/local/lib/nltk_data'
stacks-reflector-1         | **********************************************************************
```

This PR will include them, to prevent downloading them everytime the container is starting.

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)


___

### **PR Type**
Bug fix


___

### **Description**
- Pre-download NLTK packages in Docker build

- Prevent runtime errors in deployment

- Fix missing punkt_tab and averaged_perceptron_tagger resources


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Pre-download NLTK packages during Docker build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/Dockerfile

<li>Added Python command to pre-download required NLTK packages (punkt_tab <br>and averaged_perceptron_tagger)<br> <li> Added this step during Docker image build to ensure resources are <br>available at runtime<br> <li> Prevents the "Resource not found" errors in deployment


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/489/files#diff-7dcfbc368ef61cdb87ff87938d3901a82097fe398633f995dc4ab1cbee761a40">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>