### PR TITLE
fix: process meetings with utc

### DIFF
--- a/server/reflector/worker/process.py
+++ b/server/reflector/worker/process.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from urllib.parse import unquote
 
 import av
@@ -139,7 +139,10 @@ async def process_meetings():
     meetings = await meetings_controller.get_all_active()
     for meeting in meetings:
         is_active = False
-        if meeting.end_date > datetime.utcnow():
+        end_date = meeting.end_date
+        if end_date.tzinfo is None:
+            end_date = end_date.replace(tzinfo=timezone.utc)
+        if end_date > datetime.now(timezone.utc):
             response = await get_room_sessions(meeting.room_name)
             room_sessions = response.get("results", [])
             is_active = not room_sessions or any(


### PR DESCRIPTION
### **User description**
## fix: process meetings with utc

```
stacks-reflector-worker-1  | [2025-07-17 03:36:28,122: ERROR/ForkPoolWorker-1] Task reflector.worker.process.process_meetings[4c231450-c175-46e3-9543-fcc315849eef] raised unexpected: TypeError("can't compare offset-naive and offset-aware datetimes")
stacks-reflector-worker-1  | Traceback (most recent call last):
stacks-reflector-worker-1  |   File "/app/.venv/lib/python3.12/site-packages/celery/app/trace.py", line 453, in trace_task
stacks-reflector-worker-1  |     R = retval = fun(*args, **kwargs)
stacks-reflector-worker-1  |                  ^^^^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/app/.venv/lib/python3.12/site-packages/celery/app/trace.py", line 736, in __protected_call__
stacks-reflector-worker-1  |     return self.run(*args, **kwargs)
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/app/reflector/pipelines/main_live_pipeline.py", line 86, in wrapper
stacks-reflector-worker-1  |     return asyncio.run(coro)
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/usr/local/lib/python3.12/asyncio/runners.py", line 195, in run
stacks-reflector-worker-1  |     return runner.run(main)
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
stacks-reflector-worker-1  |     return self._loop.run_until_complete(task)
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/usr/local/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
stacks-reflector-worker-1  |     return future.result()
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/app/reflector/pipelines/main_live_pipeline.py", line 75, in run_with_db
stacks-reflector-worker-1  |     return await f(*args, **kwargs)
stacks-reflector-worker-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  |   File "/app/reflector/worker/process.py", line 142, in process_meetings
stacks-reflector-worker-1  |     if meeting.end_date > datetime.utcnow():
stacks-reflector-worker-1  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stacks-reflector-worker-1  | TypeError: can't compare offset-naive and offset-aware datetimes
```

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix timezone comparison in meeting processing

- Handle naive datetimes by adding UTC timezone

- Prevent TypeError when comparing datetime objects


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process.py</strong><dd><code>Fix timezone-aware datetime comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/worker/process.py

<li>Import timezone from datetime module<br> <li> Add timezone handling for meeting end_date<br> <li> Replace datetime.utcnow() with datetime.now(timezone.utc)<br> <li> Ensure end_date has UTC timezone before comparison


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/493/files#diff-68019eddc4079e7b8930374204c5fe955c3ee56cd7044ea12014af50cbc31771">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>