### PR TITLE
fix: don't attempt to load waveform/mp3 if audio was deleted

### DIFF
--- a/www/app/(app)/transcripts/topicList.tsx
+++ b/www/app/(app)/transcripts/topicList.tsx
@@ -55,8 +55,8 @@ export function TopicList({
   };
 
   useEffect(() => {
-    if (activeTopic) scrollToTopic();
-  }, [activeTopic]);
+    if (activeTopic && autoscroll) scrollToTopic();
+  }, [activeTopic, autoscroll]);
 
   // scroll top is not rounded, heights are, so exact match won't work.
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled
@@ -105,8 +105,10 @@ export function TopicList({
   const requireLogin = featureEnabled("requireLogin");
 
   useEffect(() => {
-    setActiveTopic(topics[topics.length - 1]);
-  }, [topics]);
+    if (autoscroll) {
+      setActiveTopic(topics[topics.length - 1]);
+    }
+  }, [topics, autoscroll]);
 
   return (
     <Flex

--- a/www/app/(app)/transcripts/useWaveform.ts
+++ b/www/app/(app)/transcripts/useWaveform.ts
@@ -10,16 +10,22 @@ type AudioWaveFormResponse = {
   error: Error | null;
 };
 
-const useWaveform = (id: string, waiting: boolean): AudioWaveFormResponse => {
+const useWaveform = (id: string, skip: boolean): AudioWaveFormResponse => {
   const [waveform, setWaveform] = useState<AudioWaveform | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(false);
   const [error, setErrorState] = useState<Error | null>(null);
   const { setError } = useError();
   const api = useApi();
 
   useEffect(() => {
-    if (!id || !api || waiting) return;
+    if (!id || !api || skip) {
+      setLoading(false);
+      setErrorState(null);
+      setWaveform(null);
+      return;
+    }
     setLoading(true);
+    setErrorState(null);
     api
       .v1TranscriptGetAudioWaveform({ transcriptId: id })
       .then((result) => {
@@ -29,14 +35,9 @@ const useWaveform = (id: string, waiting: boolean): AudioWaveFormResponse => {
       })
       .catch((err) => {
         setErrorState(err);
-        const shouldShowHuman = shouldShowError(err);
-        if (shouldShowHuman) {
-          setError(err, "There was an error loading the waveform");
-        } else {
-          setError(err);
-        }
+        setLoading(false);
       });
-  }, [id, !api, waiting]);
+  }, [id, api, skip]);
 
   return { waveform, loading, error };
 };


### PR DESCRIPTION
### **User description**
## fix: don't attempt to load waveform/mp3 if audio was deleted

Bug from @juanArias8

> I've been having problems with Reflector during my recent interviews. In the last one there's no audio available and in the previous one neither audio nor transcription, it simply doesn't appear
> 
>     Request URL: https://api-reflector.monadical.com/v1/transcripts/91571642-df94-4d58-a88b-a73ed0f8b597/audio/mp3
>     Request Method: GET
>     Status Code: 404 Not Found

The audio was deleted because one participant didn't gave the consent to keep the audio.
The UI is still trying to load the mp3 and the waveform, generating errors on the page.

This PR fixes it.

<img width="1086" height="174" alt="image" src="https://github.com/user-attachments/assets/c05b33e8-8170-4f8e-877f-c1afd91f9b42" />

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix audio loading when audio was deleted

- Prevent waveform loading when audio unavailable

- Improve error handling for audio/waveform loading

- Fix autoscroll behavior in topic list


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Improve UI handling for deleted audio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/[transcriptId]/page.tsx

<li>Added Box component import from Chakra UI<br> <li> Improved conditional rendering to not attempt loading waveform when <br>audio is deleted<br> <li> Enhanced error display with styled Box component<br> <li> Restructured component rendering logic to check audio deletion status <br>first


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/495/files#diff-535b6481556d1dd5698d408913a44b597bf6d58d09078d3ea7b0dd240ba40493">+24/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>topicList.tsx</strong><dd><code>Fix topic list autoscroll behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/topicList.tsx

<li>Added autoscroll dependency to useEffect hooks<br> <li> Only scroll to topic or set active topic when autoscroll is enabled


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/495/files#diff-edd6a9a5971e87be7ad53e3bf44bbc4963e6f45761a3fd9e740248f29352dd7f">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useMp3.ts</strong><dd><code>Prevent audio loading when deleted</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/useMp3.ts

<li>Restructured audio loading to first check if audio is deleted<br> <li> Only create and configure audio element if audio is not deleted<br> <li> Added proper cleanup for audio element and event listeners<br> <li> Fixed dependency array in useEffect to properly include api


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/495/files#diff-b78dfa216fc8f134d56898aee702056bfe2eab4a31e3428ee6c734eab9bce71f">+47/-40</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useWaveform.ts</strong><dd><code>Improve waveform loading logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/useWaveform.ts

<li>Renamed parameter from 'waiting' to 'skip' for clarity<br> <li> Reset waveform state when skipping loading<br> <li> Removed unnecessary error display logic<br> <li> Fixed loading state management


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/495/files#diff-894820cacda53ee5d6d7c20dda14da448aaa775b3c2166bc9b161bfa22265ac3">+11/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>