### PR TITLE
fix: remove primary color for room action menu

### DIFF
--- a/www/app/(app)/rooms/_components/RoomActionsMenu.tsx
+++ b/www/app/(app)/rooms/_components/RoomActionsMenu.tsx
@@ -18,7 +18,7 @@ export function RoomActionsMenu({
   return (
     <Menu.Root closeOnSelect={true} lazyMount={true}>
       <Menu.Trigger asChild>
-        <IconButton aria-label="actions">
+        <IconButton aria-label="actions" variant="ghost">
           <LuMenu />
         </IconButton>
       </Menu.Trigger>


### PR DESCRIPTION
### **User description**
## fix: remove primary color for room action menu

⚠️ Describe your PR replacing this text. Post screenshots or videos whenever possible. ⚠️

### Checklist

 - [ ] My branch is updated with main (mandatory)
 - [ ] I wrote unit tests for this (if applies)
 - [ ] I have included migrations and tested them locally (if applies)
 - [ ] I have manually tested this feature locally

> IMPORTANT: Remember that you are responsible for merging this PR after it's been reviewed, and once deployed
> you should perform manual testing to make sure everything went smoothly.

### Urgency

 - [ ] Urgent (deploy ASAP)
 - [ ] Non-urgent (deploying in next release is ok)


___

### **PR Type**
Bug fix


___

### **Description**
- Changed room action menu button to ghost variant


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RoomActionsMenu.tsx</strong><dd><code>Change IconButton variant to ghost</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/rooms/_components/RoomActionsMenu.tsx

<li>Changed the IconButton variant from default (primary) to "ghost" for <br>the room actions menu trigger


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/504/files#diff-d237a2981d57a3279897d7c9ce7218289e1ca85a22c5854e4eca9b018a929238">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>