### PR TITLE
fix: delayed waveform loading

### DIFF
--- a/server/reflector/views/transcripts_audio.py
+++ b/server/reflector/views/transcripts_audio.py
@@ -69,24 +69,6 @@ async def transcript_get_audio_mp3(
                 headers=resp.headers,
             )
 
-    if transcript.audio_location == "storage":
-        # proxy S3 file, to prevent issue with CORS
-        url = await transcript.get_audio_url()
-        headers = {}
-
-        copy_headers = ["range", "accept-encoding"]
-        for header in copy_headers:
-            if header in request.headers:
-                headers[header] = request.headers[header]
-
-        async with httpx.AsyncClient() as client:
-            resp = await client.request(request.method, url, headers=headers)
-            return Response(
-                content=resp.content,
-                status_code=resp.status_code,
-                headers=resp.headers,
-            )
-
     if transcript.audio_deleted:
         raise HTTPException(
             status_code=404, detail="Audio unavailable due to privacy settings"

--- a/www/app/(app)/transcripts/[transcriptId]/page.tsx
+++ b/www/app/(app)/transcripts/[transcriptId]/page.tsx
@@ -32,7 +32,7 @@ export default function TranscriptDetails(details: TranscriptDetails) {
   const topics = useTopics(transcriptId);
   const waveform = useWaveform(
     transcriptId,
-    waiting || mp3.loading || mp3.audioDeleted === true,
+    waiting || mp3.audioDeleted === true,
   );
   const useActiveTopic = useState<Topic | null>(null);
 


### PR DESCRIPTION
### **User description**
## Description
This PR fix the waveform loading/blinking waiting for the mp3. It is better to show it asap, as the mp3 still loading in the background. It does not impact the play button.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix waveform loading/blinking while MP3 loads

- Show waveform immediately while audio loads in background

- Remove redundant code in transcript_get_audio_mp3


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Remove MP3 loading dependency from waveform display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/[transcriptId]/page.tsx

<li>Removed <code>mp3.loading</code> condition from useWaveform hook parameters<br> <li> Allows waveform to display immediately without waiting for MP3 to load


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/538/files#diff-535b6481556d1dd5698d408913a44b597bf6d58d09078d3ea7b0dd240ba40493">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transcripts_audio.py</strong><dd><code>Remove duplicate code for audio file handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/transcripts_audio.py

<li>Removed duplicate code block for handling storage-based audio files<br> <li> The same code block appears twice, and the first instance was removed


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/538/files#diff-ab22659127c849d0a3cb88225e08e2e2881261f784bc51384e0b00016722c36f">+0/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>