### PR TITLE
fix: use structlog not logging

### DIFF
--- a/server/reflector/db/search.py
+++ b/server/reflector/db/search.py
@@ -1,6 +1,5 @@
 """Search functionality for transcripts and other entities."""
 
-import logging
 from datetime import datetime
 from io import StringIO
 from typing import Annotated, Any, Dict
@@ -12,8 +11,7 @@ from pydantic import BaseModel, Field, constr, field_serializer
 from reflector.db import get_database
 from reflector.db.transcripts import SourceKind, transcripts
 from reflector.db.utils import is_postgresql
-
-logger = logging.getLogger(__name__)
+from reflector.logger import logger
 
 DEFAULT_SEARCH_LIMIT = 20
 SNIPPET_CONTEXT_LENGTH = 50  # Characters before/after match to include

--- a/server/reflector/db/transcripts.py
+++ b/server/reflector/db/transcripts.py
@@ -1,6 +1,5 @@
 import enum
 import json
-import logging
 import os
 import shutil
 from contextlib import asynccontextmanager
@@ -19,13 +18,12 @@ from reflector.db import get_database, metadata
 from reflector.db.recordings import recordings_controller
 from reflector.db.rooms import rooms
 from reflector.db.utils import is_postgresql
+from reflector.logger import logger
 from reflector.processors.types import Word as ProcessorWord
 from reflector.settings import settings
 from reflector.storage import get_recordings_storage, get_transcripts_storage
 from reflector.utils import generate_uuid4
 from reflector.utils.webvtt import topics_to_webvtt
-
-logger = logging.getLogger(__name__)
 
 
 class SourceKind(enum.StrEnum):
@@ -602,7 +600,7 @@ class TranscriptController:
             except Exception as e:
                 logger.warning(
                     "Failed to delete transcript audio from storage",
-                    error=str(e),
+                    exc_info=e,
                     transcript_id=transcript.id,
                 )
         transcript.unlink()
@@ -617,14 +615,14 @@ class TranscriptController:
                     except Exception as e:
                         logger.warning(
                             "Failed to delete recording object from S3",
-                            error=str(e),
+                            exc_info=e,
                             recording_id=transcript.recording_id,
                         )
                     await recordings_controller.remove_by_id(transcript.recording_id)
             except Exception as e:
                 logger.warning(
                     "Failed to delete recording row",
-                    error=str(e),
+                    exc_info=e,
                     recording_id=transcript.recording_id,
                 )
         query = transcripts.delete().where(transcripts.c.id == transcript_id)


### PR DESCRIPTION
### **User description**
Fix to use structlog, not logging.

This will also prevent: 

```
  File "/home/tito/code/monadical/reflector/server/reflector/views/transcripts.py", line 356, in transcript_delete
    await transcripts_controller.remove_by_id(transcript.id, user_id=user_id)
  File "/home/tito/code/monadical/reflector/server/reflector/db/transcripts.py", line 625, in remove_by_id
    logger.warning(
  File "/home/tito/.local/share/uv/python/cpython-3.12.6-linux-x86_64-gnu/lib/python3.12/logging/__init__.py", line 1551, in warning
    self._log(WARNING, msg, args, **kwargs)
TypeError: Logger._log() got an unexpected keyword argument 'error'
```


___

### **PR Type**
Bug fix


___

### **Description**
- Replace logging with structlog

- Fix TypeError in logger.warning() calls

- Update imports in search.py and transcripts.py

- Change error parameter to exc_info


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search.py</strong><dd><code>Replace logging with structlog import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/db/search.py

<li>Removed direct import of logging module<br> <li> Replaced logging.getLogger() with import from reflector.logger


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/550/files#diff-660ad0b516b6a319ddfadecdf3aac5d8770e6f771ce2c10888573fc58722d91c">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transcripts.py</strong><dd><code>Fix logger parameter in exception handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/db/transcripts.py

<li>Removed direct import of logging module<br> <li> Replaced logging.getLogger() with import from reflector.logger<br> <li> Changed error parameter to exc_info in warning calls to fix TypeError


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/550/files#diff-cb4fc52fe1297f4d5ccfeb99d710212805f36eafa816e0472b19a8d8d8bc6151">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>