### PR TITLE
chore: diarization cli: throw on modal errors

### DIFF
--- a/server/reflector/processors/base.py
+++ b/server/reflector/processors/base.py
@@ -173,6 +173,7 @@ class Processor(Emitter):
         except Exception:
             self.m_processor_failure.inc()
             self.logger.exception("Error in push")
+            raise
 
     async def flush(self):
         """


### PR DESCRIPTION
when modal has an error (500 in my case), cli should stop

tested it catching https://monadical-sas--reflector-diarizer-web.modal.run/diarize?__modal_function_call_id=fc-01K322MX9E98WNCQXE1CR17CAN 500