### PR TITLE
fix: webvtt db null expectation mismatch

### DIFF
--- a/server/reflector/db/search.py
+++ b/server/reflector/db/search.py
@@ -45,7 +45,7 @@ SearchTotal = Annotated[
     SearchTotalBase, Field(description="Total number of search results")
 ]
 
-WEBVTT_SPEC_HEADER = "WEBVTT\n\n"
+WEBVTT_SPEC_HEADER = "WEBVTT"
 
 WebVTTContent = Annotated[
     str,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed WebVTT header format mismatch


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>search.py</strong><dd><code>Update WebVTT header constant definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/db/search.py

<li>Changed <code>WEBVTT_SPEC_HEADER</code> constant from "WEBVTT\n\n" to "WEBVTT"<br> <li> This fixes a mismatch between expected WebVTT header format and <br>database values


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/556/files#diff-660ad0b516b6a319ddfadecdf3aac5d8770e6f771ce2c10888573fc58722d91c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>