### PR TITLE
fix: kv use tls explicit

### DIFF
--- a/www/app/lib/redisClient.ts
+++ b/www/app/lib/redisClient.ts
@@ -3,6 +3,10 @@ import { isBuildPhase } from "./next";
 
 export type RedisClient = Pick<Redis, "get" | "setex" | "del">;
 
+const KV_USE_TLS = process.env.KV_USE_TLS
+  ? process.env.KV_USE_TLS === "true"
+  : undefined;
+
 const getRedisClient = (): RedisClient => {
   const redisUrl = process.env.KV_URL;
   if (!redisUrl) {
@@ -11,6 +15,11 @@ const getRedisClient = (): RedisClient => {
   const redis = new Redis(redisUrl, {
     maxRetriesPerRequest: 3,
     lazyConnect: true,
+    ...(KV_USE_TLS === true
+      ? {
+          tls: {},
+        }
+      : {}),
   });
 
   redis.on("error", (error) => {


### PR DESCRIPTION
### **User description**
redis client gets "redis" from env but we expect "rediss" but we dont control env so we get around by having an ssl env var


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit TLS configuration for Redis client

- Use KV_USE_TLS environment variable to control TLS


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redisClient.ts</strong><dd><code>Add explicit TLS configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/lib/redisClient.ts

<li>Added KV_USE_TLS environment variable parsing<br> <li> Conditionally added TLS configuration to Redis client options<br> <li> Enables explicit TLS control when Redis URL scheme can't be controlled


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/610/files#diff-f09470b799bb5352facddfdfe6a076e7ce4a45a64dd1f71466be7eacf248d26b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>