### PR TITLE
chore: removal of email-verified from /me

### DIFF
--- a/server/reflector/views/user.py
+++ b/server/reflector/views/user.py
@@ -11,7 +11,6 @@ router = APIRouter()
 class UserInfo(BaseModel):
     sub: str
     email: Optional[str]
-    email_verified: Optional[bool]
 
 
 @router.get("/me")

--- a/www/app/reflector-api.d.ts
+++ b/www/app/reflector-api.d.ts
@@ -1518,8 +1518,6 @@ export interface components {
       sub: string;
       /** Email */
       email: string | null;
-      /** Email Verified */
-      email_verified: boolean | null;
     };
     /** ValidationError */
     ValidationError: {


### PR DESCRIPTION
### **User description**
it made /me not work

it's a relic of fief auth

additionally, the removal of it improves the consistency of the api response: {email:null, email_verified: true} becomes impossible


___

### **PR Type**
Enhancement


___

### **Description**
- Remove email_verified field from user info

- Simplify API response structure

- Eliminate inconsistent state possibility


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.py</strong><dd><code>Remove email_verified field from UserInfo model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/user.py

- Removed the `email_verified` field from the UserInfo model


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/707/files#diff-67c9d6cf3473ec1e40ca551c78b431791106d2e8938efd58a58645627af17f78">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reflector-api.d.ts</strong><dd><code>Update TypeScript interface to remove email_verified</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/reflector-api.d.ts

<li>Removed the <code>email_verified</code> field from the TypeScript interface <br>definition


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/707/files#diff-b9bbe7063429a32f751e2a5f5ba9b75fe599f7e4f0e13a0ea115da9144eb1489">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>