### PR TITLE
fix: parakeet vad not getting the end timestamp

### DIFF
--- a/gpu/modal_deployments/reflector_transcriber_parakeet.py
+++ b/gpu/modal_deployments/reflector_transcriber_parakeet.py
@@ -81,9 +81,9 @@ image = (
         "cuda-python==12.8.0",
         "fastapi==0.115.12",
         "numpy<2",
-        "librosa==0.10.1",
+        "librosa==0.11.0",
         "requests",
-        "silero-vad==5.1.0",
+        "silero-vad==6.2.0",
         "torch",
     )
     .entrypoint([])  # silence chatty logs by container on start
@@ -306,6 +306,7 @@ class TranscriberParakeetFile:
         ) -> Generator[TimeSegment, None, None]:
             """Generate speech segments using VAD with start/end sample indices"""
             vad_iterator = VADIterator(self.vad_model, sampling_rate=SAMPLERATE)
+            audio_duration = len(audio_array) / float(SAMPLERATE)
             window_size = VAD_CONFIG["window_size"]
             start = None
 
@@ -331,6 +332,10 @@ class TranscriberParakeetFile:
 
                     yield TimeSegment(start_time, end_time)
                     start = None
+
+            if start is not None:
+                start_time = start / float(SAMPLERATE)
+                yield TimeSegment(start_time, audio_duration)
 
             vad_iterator.reset_states()
 


### PR DESCRIPTION
### **User description**
## Description
This PR fix the VADIterator not emitting the "end" on the last speech_dict. In their example (https://github.com/snakers4/silero-vad/wiki/Examples-and-Dependencies), they don't indicate that it's not possible, but it can happen.

Emitting the latest `TimeSegment` with audio_duration if a start was detected but not ended works.

## How Has This Been Tested?

Tested from the server directory: `uv run --with librosa==0.11 --with silero_vad==6.2.0 python ../gpu/modal_deployments/localvad.py ~/Downloads/audio/padded_0.webm`

And here is the `localvad.py`:
```
# local silero vad
import sys
import librosa
import silero_vad
import numpy as np

window_size = 512
sampling_rate = 16000
filename = sys.argv[1]

print("SILERO", silero_vad.__version__)
print("LIBROSA", librosa.__version__)

print("LOAD AUDIO", filename)
audio, sr = librosa.load(filename, sr=sampling_rate, mono=True)
print("LOAD SILERO")
model = silero_vad.load_silero_vad()
print("START/STOP WITH get_speech_timestamps")
print(
    silero_vad.get_speech_timestamps(
        audio, model, sampling_rate=sampling_rate, return_seconds=True
    )
)
print("ITERATE")
vad_iterator = silero_vad.VADIterator(model, sampling_rate=16000)
for i in range(0, len(audio), window_size):
    chunk = audio[i : i + window_size]
    if len(chunk) < window_size:
        chunk = np.pad(chunk, (0, window_size - len(chunk)), mode="constant")
    vad_result = vad_iterator(chunk, return_seconds=True)
    if vad_result:
        print(vad_result)
        if "start" in vad_result:
            start = vad_result["start"]
            continue
        elif "end" in vad_result:
            end = vad_result["end"]
            print("Speech", start, end)
            start = None
if start is not None:
    audio_duration = len(audio) / sampling_rate
    print("Speech [last]", start, audio_duration)
vad_iterator.reset_states()
```


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix VADIterator not emitting end timestamp

- Update silero-vad and librosa dependencies

- Handle speech segments that end with audio


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reflector_transcriber_parakeet.py</strong><dd><code>Fix VAD timestamp handling and update dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gpu/modal_deployments/reflector_transcriber_parakeet.py

<li>Updated librosa from 0.10.1 to 0.11.0<br> <li> Updated silero-vad from 5.1.0 to 6.2.0<br> <li> Added audio_duration calculation for the entire audio<br> <li> Added handling for speech segments that start but don't end before <br>audio finishes


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/728/files#diff-4eeb3600a14bcc0dc6e7b94a37438f40bacc4a826c5c1e4d75f3d741e595c7b9">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>