### PR TITLE
fix: room creation hotfix

### DIFF
--- a/server/reflector/views/rooms.py
+++ b/server/reflector/views/rooms.py
@@ -248,7 +248,7 @@ async def rooms_create(
         ics_url=room.ics_url,
         ics_fetch_interval=room.ics_fetch_interval,
         ics_enabled=room.ics_enabled,
-        platform=room.platform,
+        platform=room.platform or settings.DEFAULT_VIDEO_PLATFORM,
     )
 
 


### PR DESCRIPTION
### **User description**
forgotten default / room creation crash happens


___

### **PR Type**
Bug fix


___

### **Description**
- Fix room creation crash by adding default platform fallback


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rooms.py</strong><dd><code>Add default platform fallback for room creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/rooms.py

<li>Added fallback to <code>settings.DEFAULT_VIDEO_PLATFORM</code> when <code>room.platform</code> <br>is None<br> <li> Prevents crash during room creation when platform is not specified


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/744/files#diff-f4f3fba07cab0004d948ecb2a506ae0c27418cc030b22d433f99acd40be8eb63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>