### PR TITLE
feat: is_owner pass for dailyco

### DIFF
--- a/server/reflector/video_platforms/daily.py
+++ b/server/reflector/video_platforms/daily.py
@@ -173,15 +173,16 @@ class DailyClient(VideoPlatformClient):
         self,
         room_name: DailyRoomName,
         enable_recording: bool,
-        user_id: str | None = None,
-    ) -> str:
+        user_id: NonEmptyString | None = None,
+        is_owner: bool = False,
+    ) -> NonEmptyString:
         properties = MeetingTokenProperties(
             room_name=room_name,
             user_id=user_id,
             start_cloud_recording=enable_recording,
-            enable_recording_ui=not enable_recording,
+            enable_recording_ui=False,
+            is_owner=is_owner,
         )
-
         request = CreateMeetingTokenRequest(properties=properties)
         result = await self._api_client.create_meeting_token(request)
         return result.token

--- a/server/reflector/views/rooms.py
+++ b/server/reflector/views/rooms.py
@@ -248,7 +248,7 @@ async def rooms_create(
         ics_url=room.ics_url,
         ics_fetch_interval=room.ics_fetch_interval,
         ics_enabled=room.ics_enabled,
-        platform=room.platform,
+        platform=room.platform or settings.DEFAULT_VIDEO_PLATFORM,
     )
 
 
@@ -556,6 +556,7 @@ async def rooms_join_meeting(
             meeting.room_name,
             enable_recording=enable_recording,
             user_id=user_id,
+            is_owner=user_id == room.user_id,
         )
         meeting = meeting.model_copy()
         meeting.room_url = add_query_param(meeting.room_url, "t", token)


### PR DESCRIPTION
### **User description**
passing is_admin for dailyco rooms when room owner is the user

!!! differs from how Whereby do it !!!

we have dynamically generated meeting token instead of static whereby url / host_url

for daily meetings host_url field is not used

more room properties for reference: https://docs.daily.co/reference/rest-api/rooms/create-room#properties (not in this PR / call)


___

### **PR Type**
Enhancement


___

### **Description**
- Pass is_owner flag to Daily.co meetings

- Disable recording UI for all users

- Set default video platform when missing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daily.py</strong><dd><code>Add owner permissions to Daily.co meeting tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/video_platforms/daily.py

<li>Added <code>is_owner</code> parameter to <code>create_meeting_token</code> method<br> <li> Set <code>is_owner</code> flag in meeting token properties<br> <li> Disabled recording UI for all users (<code>enable_recording_ui=False</code>)<br> <li> Added warning log for debugging is_owner status<br> <li> Improved type annotations with <code>NonEmptyString</code>


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/745/files#diff-bbf311ce9b79244712d209ecd2931009ac6f75da1a7432777997d661c0248700">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rooms.py</strong><dd><code>Pass room ownership status to video platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/rooms.py

<li>Pass <code>is_owner=True</code> when joining user is the room owner<br> <li> Set default video platform when room platform is None


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/745/files#diff-f4f3fba07cab0004d948ecb2a506ae0c27418cc030b22d433f99acd40be8eb63">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>