### PR TITLE
fix: hide rooms settings instead of disabling

### DIFF
--- a/www/app/(app)/rooms/page.tsx
+++ b/www/app/(app)/rooms/page.tsx
@@ -537,6 +537,10 @@ export default function RoomsList() {
                               room.recordingType === "cloud"
                                 ? "automatic-2nd-participant"
                                 : "none";
+                          } else {
+                            if (room.recordingType !== "cloud") {
+                              updates.recordingTrigger = "none";
+                            }
                           }
                           setRoomInput({ ...room, ...updates });
                         }}
@@ -662,14 +666,12 @@ export default function RoomsList() {
                           const updates: Partial<typeof room> = {
                             recordingType: newRecordingType,
                           };
-                          // For Daily: if cloud, use automatic; otherwise none
                           if (room.platform === "daily") {
                             updates.recordingTrigger =
                               newRecordingType === "cloud"
                                 ? "automatic-2nd-participant"
                                 : "none";
                           } else {
-                            // For Whereby: if not cloud, set to none
                             updates.recordingTrigger =
                               newRecordingType !== "cloud"
                                 ? "none"


### PR DESCRIPTION
### **User description**
<img width="686" height="856" alt="Screenshot 2025-12-02 at 19 14 15" src="https://github.com/user-attachments/assets/1c1d8ae8-dcf3-47b9-b654-8d0329742d72" />
<img width="685" height="751" alt="Screenshot 2025-12-02 at 19 14 20" src="https://github.com/user-attachments/assets/977ff05a-6449-44d1-8492-2db379d7ce60" />
<img width="689" height="573" alt="Screenshot 2025-12-02 at 19 14 45" src="https://github.com/user-attachments/assets/839344c1-db04-40de-b316-68636817ec41" />


___

### **PR Type**
Enhancement


___

### **Description**
- Hide platform-specific settings instead of disabling

- Add help tooltips for recording options

- Improve UI with conditional rendering

- Reorganize room settings with better grouping


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Enhance room settings UI with conditional rendering and tooltips</code></dd></summary>
<hr>

www/app/(app)/rooms/page.tsx

<li>Replaced disabled controls with conditional rendering for <br>platform-specific settings<br> <li> Added informational tooltips for recording type and trigger options<br> <li> Improved UI organization with HStack for label-icon pairs<br> <li> Added detailed explanations for recording options in popover <br>components


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/763/files#diff-d9e25644aab05694b4656c095fe8350e826557fa52540eeeb7003a069ea09f77">+143/-71</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>