### PR TITLE
fix: celery inspect bug sidestep in restart script

### DIFF
--- a/server/reflector/services/transcript_process.py
+++ b/server/reflector/services/transcript_process.py
@@ -160,8 +160,8 @@ def dispatch_transcript_processing(config: ProcessingConfig) -> AsyncResult:
 def task_is_scheduled_or_active(task_name: str, **kwargs):
     inspect = celery.current_app.control.inspect()
 
-    scheduled = inspect.scheduled() or []
-    active = inspect.active() or []
+    scheduled = inspect.scheduled() or {}
+    active = inspect.active() or {}
     all = scheduled | active
     for worker, tasks in all.items():
         for task in tasks:


### PR DESCRIPTION
### **User description**
New exception: [TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType'](https://sentry.io/organizations/monadical/issues/7082474234/events/d65f7334e7dd44e9a7c38461566a914e/)

level: error
timestamp: 2025-12-02 22:13:40
filename: /app/reflector/services/transcript_process.py

Traceback:

     def task_is_scheduled_or_active(task_name: str, **kwargs):
         inspect = celery.current_app.control.inspect()

--->     for worker, tasks in (inspect.scheduled() | inspect.active()).items():
             for task in tasks:
                 if task["name"] == task_name and task["kwargs"] == kwargs:
                     return True


___

### **PR Type**
Bug fix


___

### **Description**
- Fix TypeError in task_is_scheduled_or_active function

- Handle None values from Celery inspect calls

- Prevent operation on NoneType objects


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transcript_process.py</strong><dd><code>Fix Celery inspect NoneType error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/services/transcript_process.py

<li>Fixed TypeError by handling potential None returns from <br>inspect.scheduled() and inspect.active()<br> <li> Added fallback empty lists when Celery inspect methods return None<br> <li> Separated dictionary union operation to prevent NoneType operand error


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/766/files#diff-9cf239e6690456b5168c6532b7655499e8f054e1ab4e3a882275a03db34e88a6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>