### PR TITLE
fix: populate room_name in transcript GET endpoint

### DIFF
--- a/server/reflector/views/transcripts.py
+++ b/server/reflector/views/transcripts.py
@@ -17,6 +17,7 @@ from pydantic import (
 import reflector.auth as auth
 from reflector.db import get_database
 from reflector.db.recordings import recordings_controller
+from reflector.db.rooms import rooms_controller
 from reflector.db.search import (
     DEFAULT_SEARCH_LIMIT,
     SearchLimit,
@@ -473,6 +474,11 @@ async def transcript_get(
 
     is_multitrack = await _get_is_multitrack(transcript)
 
+    room_name = None
+    if transcript.room_id:
+        room = await rooms_controller.get_by_id(transcript.room_id)
+        room_name = room.name if room else None
+
     participants = []
     if transcript.participants:
         user_ids = [p.user_id for p in transcript.participants if p.user_id is not None]
@@ -503,6 +509,7 @@ async def transcript_get(
         "meeting_id": transcript.meeting_id,
         "source_kind": transcript.source_kind,
         "room_id": transcript.room_id,
+        "room_name": room_name,
         "audio_deleted": transcript.audio_deleted,
         "participants": participants,
     }

--- a/server/tests/test_transcripts.py
+++ b/server/tests/test_transcripts.py
@@ -1,5 +1,8 @@
 import pytest
 
+from reflector.db.rooms import rooms_controller
+from reflector.db.transcripts import transcripts_controller
+
 
 @pytest.mark.asyncio
 async def test_transcript_create(client):
@@ -182,3 +185,51 @@ async def test_transcript_mark_reviewed(authenticated_client, client):
     response = await client.get(f"/transcripts/{tid}")
     assert response.status_code == 200
     assert response.json()["reviewed"] is True
+
+
+@pytest.mark.asyncio
+async def test_transcript_get_returns_room_name(authenticated_client, client):
+    """Test that getting a transcript returns its room_name when linked to a room."""
+    # Create a room
+    room = await rooms_controller.add(
+        name="test-room-for-transcript",
+        user_id="test-user",
+        zulip_auto_post=False,
+        zulip_stream="",
+        zulip_topic="",
+        is_locked=False,
+        room_mode="normal",
+        recording_type="cloud",
+        recording_trigger="automatic-2nd-participant",
+        is_shared=False,
+        webhook_url="",
+        webhook_secret="",
+    )
+
+    # Create a transcript linked to the room
+    transcript = await transcripts_controller.add(
+        name="transcript-with-room",
+        source_kind="file",
+        room_id=room.id,
+    )
+
+    # Get the transcript and verify room_name is returned
+    response = await client.get(f"/transcripts/{transcript.id}")
+    assert response.status_code == 200
+    assert response.json()["room_id"] == room.id
+    assert response.json()["room_name"] == "test-room-for-transcript"
+
+
+@pytest.mark.asyncio
+async def test_transcript_get_returns_null_room_name_when_no_room(
+    authenticated_client, client
+):
+    """Test that room_name is null when transcript has no room."""
+    response = await client.post("/transcripts", json={"name": "no-room-transcript"})
+    assert response.status_code == 200
+    tid = response.json()["id"]
+
+    response = await client.get(f"/transcripts/{tid}")
+    assert response.status_code == 200
+    assert response.json()["room_id"] is None
+    assert response.json()["room_name"] is None


### PR DESCRIPTION
### **User description**
## Summary

- Fix `room_name` always being `null` in `GET /v1/transcripts/{id}` endpoint
- Fetch room name from the rooms table when `room_id` is present

Fixes https://gitea.app.monadical.io/monadical/internalai/issues/14

## Change

```python
# Fetch room name if room_id is present
room_name = None
if transcript.room_id:
    room = await rooms_controller.get_by_id(transcript.room_id)
    room_name = room.name if room else None
```

## Test plan

- [x] Added test for transcript with room returning `room_name`
- [x] Added test for transcript without room returning `null`
- [x] All existing tests pass


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix room_name always being null in transcript endpoint

- Fetch room name from rooms table when room_id exists

- Add tests for room_name in transcript responses


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transcripts.py</strong><dd><code>Add room_name fetching and response field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/views/transcripts.py

<li>Import rooms_controller to access room data<br> <li> Add logic to fetch room name when transcript has room_id<br> <li> Include room_name in the transcript response payload


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/783/files#diff-403f4714db2253ef651c42aeed2643ad19d2066f061cbc0ba389064421c5d81b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_transcripts.py</strong><dd><code>Add tests for room_name in transcript responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/test_transcripts.py

<li>Import rooms_controller and transcripts_controller<br> <li> Add test for transcript with room returning correct room_name<br> <li> Add test for transcript without room returning null room_name


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/783/files#diff-f11ce422d2b17ff437e82684f8602ceb42ad03447b8c85a5e97a1ca484755b10">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>