### PR TITLE
better hatchet concurrency limits

### DIFF
--- a/server/reflector/hatchet/workflows/topic_chunk_processing.py
+++ b/server/reflector/hatchet/workflows/topic_chunk_processing.py
@@ -7,12 +7,12 @@ Spawned dynamically by detect_topics via aio_run_many() for parallel processing.
 
 from datetime import timedelta
 
-from hatchet_sdk import Context
+from hatchet_sdk import ConcurrencyExpression, Context
 from hatchet_sdk.rate_limit import RateLimit
 from pydantic import BaseModel
 
 from reflector.hatchet.client import HatchetClientManager
-from reflector.hatchet.constants import LLM_RATE_LIMIT_KEY, TIMEOUT_SHORT
+from reflector.hatchet.constants import LLM_RATE_LIMIT_KEY, TIMEOUT_MEDIUM
 from reflector.hatchet.workflows.models import TopicChunkResult
 from reflector.logger import logger
 from reflector.processors.prompts import TOPIC_PROMPT
@@ -32,12 +32,17 @@ class TopicChunkInput(BaseModel):
 hatchet = HatchetClientManager.get_client()
 
 topic_chunk_workflow = hatchet.workflow(
-    name="TopicChunkProcessing", input_validator=TopicChunkInput
+    name="TopicChunkProcessing",
+    input_validator=TopicChunkInput,
+    concurrency=ConcurrencyExpression(
+        expression="true",  # constant CEL expression = global limit
+        max_runs=20,
+    ),
 )
 
 
 @topic_chunk_workflow.task(
-    execution_timeout=timedelta(seconds=TIMEOUT_SHORT),
+    execution_timeout=timedelta(seconds=TIMEOUT_MEDIUM),
     retries=3,
     rate_limits=[RateLimit(static_key=LLM_RATE_LIMIT_KEY, units=1)],
 )


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved concurrency limits for Hatchet workflows

- Extended execution timeout for topic detection

- Added global concurrency control with max_runs=20


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>topic_chunk_processing.py</strong><dd><code>Add concurrency limits and extend execution timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/hatchet/workflows/topic_chunk_processing.py

<li>Imported <code>ConcurrencyExpression</code> from hatchet_sdk<br> <li> Changed timeout from SHORT to MEDIUM for task execution<br> <li> Added global concurrency control with max_runs=20<br> <li> Updated workflow configuration with explicit concurrency limits


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/807/files#diff-3d15ff04d05a93b014547ac0def012640ad645d6663ad65f7b2c7ee8a97a0b96">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>