### PR TITLE
[uiv2-followups] general changes in uiv2-followups.md file 

### DIFF
--- a/scripts/setup-selfhosted.sh
+++ b/scripts/setup-selfhosted.sh
@@ -190,19 +190,23 @@ env_set() {
 }
 
 compose_cmd() {
-    local profiles="" files="-f $COMPOSE_FILE"
-    [[ "$USE_CUSTOM_CA" == "true" ]] && files="$files -f $ROOT_DIR/docker-compose.ca.yml"
+    local args=("-f" "$COMPOSE_FILE")
+    if [[ "$USE_CUSTOM_CA" == "true" ]]; then
+        args+=("-f" "$ROOT_DIR/docker-compose.ca.yml")
+    fi
     for p in "${COMPOSE_PROFILES[@]}"; do
-        profiles="$profiles --profile $p"
+        args+=("--profile" "$p")
     done
-    docker compose $files $profiles "$@"
+    docker compose "${args[@]}" "$@"
 }
 
 # Compose command with only garage profile (for garage-only operations before full stack start)
 compose_garage_cmd() {
-    local files="-f $COMPOSE_FILE"
-    [[ "$USE_CUSTOM_CA" == "true" ]] && files="$files -f $ROOT_DIR/docker-compose.ca.yml"
-    docker compose $files --profile garage "$@"
+    local args=("-f" "$COMPOSE_FILE")
+    if [[ "$USE_CUSTOM_CA" == "true" ]]; then
+        args+=("-f" "$ROOT_DIR/docker-compose.ca.yml")
+    fi
+    docker compose "${args[@]}" --profile garage "$@"
 }
 
 # --- Config memory: replay last args if none provided ---

--- a/server/reflector/db/transcripts.py
+++ b/server/reflector/db/transcripts.py
@@ -227,7 +227,7 @@ class Transcript(BaseModel):
     topics: list[TranscriptTopic] = []
     events: list[TranscriptEvent] = []
     participants: list[TranscriptParticipant] | None = []
-    source_language: str = "en"
+    source_language: str | None = None
     target_language: str = "en"
     share_mode: Literal["private", "semi-private", "public"] = "private"
     audio_location: str = "local"
@@ -584,7 +584,7 @@ class TranscriptController:
         self,
         name: str,
         source_kind: SourceKind,
-        source_language: str = "en",
+        source_language: str | None = None,
         target_language: str = "en",
         user_id: str | None = None,
         recording_id: str | None = None,

--- a/server/reflector/pipelines/main_live_pipeline.py
+++ b/server/reflector/pipelines/main_live_pipeline.py
@@ -386,7 +386,13 @@ class PipelineMainLive(PipelineMainBase):
         ]
         pipeline = Pipeline(*processors)
         pipeline.options = self
-        pipeline.set_pref("audio:source_language", transcript.source_language)
+        # Live-pipeline processors expect a concrete language label; None means
+        # "auto-detect" at create time but the live ASR backends still seed a
+        # value (Whisper auto-detects regardless). Fall back to "en" for the
+        # pref so downstream consumers that lack a None branch keep working.
+        pipeline.set_pref(
+            "audio:source_language", transcript.source_language or "en"
+        )
         pipeline.set_pref("audio:target_language", transcript.target_language)
         pipeline.logger.bind(transcript_id=transcript.id)
         pipeline.logger.info("Pipeline main live created")

--- a/server/reflector/processors/file_transcript.py
+++ b/server/reflector/processors/file_transcript.py
@@ -7,8 +7,10 @@ from reflector.processors.types import Transcript
 class FileTranscriptInput:
     """Input for file transcription containing audio URL and language settings"""
 
-    def __init__(self, audio_url: str, language: str = "en"):
+    def __init__(self, audio_url: str, language: str | None = None):
         self.audio_url = audio_url
+        # None signals auto-detect — downstream backends omit the `language`
+        # param so the transcription model detects from audio.
         self.language = language
 
 

--- a/server/reflector/processors/file_transcript_modal.py
+++ b/server/reflector/processors/file_transcript_modal.py
@@ -45,15 +45,19 @@ class FileTranscriptModalProcessor(FileTranscriptProcessor):
         if self.modal_api_key:
             headers["Authorization"] = f"Bearer {self.modal_api_key}"
 
+        # Omit `language` when None so Modal/Whisper auto-detects the source.
+        body: dict = {
+            "audio_file_url": data.audio_url,
+            "batch": True,
+        }
+        if data.language is not None:
+            body["language"] = data.language
+
         async with httpx.AsyncClient(timeout=self.file_timeout) as client:
             response = await client.post(
                 url,
                 headers=headers,
-                json={
-                    "audio_file_url": data.audio_url,
-                    "language": data.language,
-                    "batch": True,
-                },
+                json=body,
                 follow_redirects=True,
             )
 

--- a/server/reflector/views/transcripts.py
+++ b/server/reflector/views/transcripts.py
@@ -203,7 +203,9 @@ GetTranscript = Annotated[
 
 class CreateTranscript(BaseModel):
     name: str
-    source_language: str = Field("en")
+    # None signals auto-detect — pipeline omits the `language` param so
+    # the transcription backend (Whisper / Parakeet) detects the source.
+    source_language: str | None = Field(None)
     target_language: str = Field("en")
     source_kind: SourceKind | None = None
 
@@ -386,6 +388,30 @@ class GetTranscriptSegmentTopic(BaseModel):
     text: str
     start: float
     speaker: int
+    translation: str | None = None
+
+
+def _norm_segment_text(text: str) -> str:
+    """Whitespace-collapsed lowercase key used to match an as_segments() text
+    back to a TRANSCRIPT event's text, since the segment is reconstructed
+    from words and may differ from the event text in whitespace only."""
+    return " ".join(text.lower().split())
+
+
+def _build_translation_map(events: list) -> dict[str, str]:
+    """Build a {normalized_text -> translation} lookup from a transcript's
+    TRANSCRIPT events. Used by the topics endpoint to surface translations
+    that were captured live but never threaded into the topic/word model."""
+    out: dict[str, str] = {}
+    for ev in events or []:
+        if getattr(ev, "event", None) != "TRANSCRIPT":
+            continue
+        data = getattr(ev, "data", None) or {}
+        text = (data.get("text") or "").strip()
+        translation = data.get("translation")
+        if text and translation:
+            out[_norm_segment_text(text)] = translation
+    return out
 
 
 class GetTranscriptTopic(BaseModel):
@@ -398,7 +424,13 @@ class GetTranscriptTopic(BaseModel):
     segments: list[GetTranscriptSegmentTopic] = []
 
     @classmethod
-    def from_transcript_topic(cls, topic: TranscriptTopic, is_multitrack: bool = False):
+    def from_transcript_topic(
+        cls,
+        topic: TranscriptTopic,
+        is_multitrack: bool = False,
+        translations: dict[str, str] | None = None,
+    ):
+        tmap = translations or {}
         if not topic.words:
             # In previous version, words were missing
             # Just output a segment with speaker 0
@@ -409,6 +441,7 @@ class GetTranscriptTopic(BaseModel):
                     text=topic.transcript,
                     start=topic.timestamp,
                     speaker=0,
+                    translation=tmap.get(_norm_segment_text(topic.transcript)),
                 )
             ]
         else:
@@ -421,6 +454,7 @@ class GetTranscriptTopic(BaseModel):
                     text=segment.text,
                     start=segment.start,
                     speaker=segment.speaker,
+                    translation=tmap.get(_norm_segment_text(segment.text)),
                 )
                 for segment in transcript.as_segments(is_multitrack)
             ]
@@ -439,8 +473,15 @@ class GetTranscriptTopicWithWords(GetTranscriptTopic):
     words: list[Word] = []
 
     @classmethod
-    def from_transcript_topic(cls, topic: TranscriptTopic, is_multitrack: bool = False):
-        instance = super().from_transcript_topic(topic, is_multitrack)
+    def from_transcript_topic(
+        cls,
+        topic: TranscriptTopic,
+        is_multitrack: bool = False,
+        translations: dict[str, str] | None = None,
+    ):
+        instance = super().from_transcript_topic(
+            topic, is_multitrack, translations=translations
+        )
         if topic.words:
             instance.words = topic.words
         return instance
@@ -455,8 +496,15 @@ class GetTranscriptTopicWithWordsPerSpeaker(GetTranscriptTopic):
     words_per_speaker: list[SpeakerWords] = []
 
     @classmethod
-    def from_transcript_topic(cls, topic: TranscriptTopic, is_multitrack: bool = False):
-        instance = super().from_transcript_topic(topic, is_multitrack)
+    def from_transcript_topic(
+        cls,
+        topic: TranscriptTopic,
+        is_multitrack: bool = False,
+        translations: dict[str, str] | None = None,
+    ):
+        instance = super().from_transcript_topic(
+            topic, is_multitrack, translations=translations
+        )
         if topic.words:
             words_per_speakers = []
             # group words by speaker
@@ -686,10 +734,13 @@ async def transcript_get_topics(
     )
 
     is_multitrack = await _get_is_multitrack(transcript)
+    translations = _build_translation_map(transcript.events)
 
     # convert to GetTranscriptTopic
     return [
-        GetTranscriptTopic.from_transcript_topic(topic, is_multitrack)
+        GetTranscriptTopic.from_transcript_topic(
+            topic, is_multitrack, translations=translations
+        )
         for topic in transcript.topics
     ]
 
@@ -708,10 +759,13 @@ async def transcript_get_topics_with_words(
     )
 
     is_multitrack = await _get_is_multitrack(transcript)
+    translations = _build_translation_map(transcript.events)
 
     # convert to GetTranscriptTopicWithWords
     return [
-        GetTranscriptTopicWithWords.from_transcript_topic(topic, is_multitrack)
+        GetTranscriptTopicWithWords.from_transcript_topic(
+            topic, is_multitrack, translations=translations
+        )
         for topic in transcript.topics
     ]
 

--- a/ui/src/api/schema.d.ts
+++ b/ui/src/api/schema.d.ts
@@ -1155,9 +1155,9 @@ export interface components {
             name: string;
             /**
              * Source Language
-             * @default en
+             * null = auto-detect
              */
-            source_language: string;
+            source_language?: string | null;
             /**
              * Target Language
              * @default en
@@ -1238,6 +1238,10 @@ export interface components {
             start: number;
             /** Speaker */
             speaker: number;
+            /** Translation — populated when the transcript was captured
+             *  with a target_language and a TRANSCRIPT WS event carried
+             *  the segment's translation. null otherwise. */
+            translation?: string | null;
         };
         /** GetTranscriptTopic */
         GetTranscriptTopic: {

--- a/ui/src/auth/RequireAuth.tsx
+++ b/ui/src/auth/RequireAuth.tsx
@@ -8,15 +8,7 @@ export function RequireAuth({ children }: { children: ReactNode }) {
 
   if (loading) {
     return (
-      <div
-        style={{
-          height: '100vh',
-          display: 'grid',
-          placeItems: 'center',
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-sans)',
-        }}
-      >
+      <div className="h-screen grid place-items-center text-fg-muted font-sans">
         Loading…
       </div>
     )

--- a/ui/src/components/browse/ConfirmDialog.tsx
+++ b/ui/src/components/browse/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from 'react'
 import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
+import { cn } from '@/lib/utils'
 
 type Props = {
   title: string
@@ -35,72 +36,40 @@ export function ConfirmDialog({
     <>
       <div className="rf-modal-backdrop" onClick={() => !loading && onClose()} />
       <div
-        className="rf-modal"
+        className="rf-modal w-[min(440px,calc(100vw-32px))]"
         role="dialog"
         aria-modal="true"
-        style={{ width: 'min(440px, calc(100vw - 32px))' }}
       >
-        <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <div className="p-6 flex flex-col gap-3">
+          <div className="flex items-start gap-3">
             <div
-              style={{
-                flexShrink: 0,
-                width: 36,
-                height: 36,
-                borderRadius: 10,
-                background: danger
-                  ? 'color-mix(in srgb, var(--destructive) 12%, transparent)'
-                  : 'var(--muted)',
-                color: danger ? 'var(--destructive)' : 'var(--fg-muted)',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              className={cn(
+                'shrink-0 w-9 h-9 rounded-[10px] inline-flex items-center justify-center',
+                danger
+                  ? 'bg-[color-mix(in_srgb,var(--destructive)_12%,transparent)] text-destructive'
+                  : 'bg-muted text-fg-muted',
+              )}
             >
               {I.Trash(18)}
             </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <h2
-                style={{
-                  margin: 0,
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 18,
-                  fontWeight: 600,
-                  color: 'var(--fg)',
-                }}
-              >
+            <div className="flex-1 min-w-0">
+              <h2 className="m-0 font-serif text-lg font-semibold text-fg">
                 {title}
               </h2>
-              <div
-                style={{
-                  margin: '6px 0 0',
-                  fontSize: 13,
-                  color: 'var(--fg-muted)',
-                  lineHeight: 1.5,
-                  fontFamily: 'var(--font-sans)',
-                }}
-              >
+              <div className="mt-1.5 text-[13px] text-fg-muted leading-[1.5] font-sans">
                 {message}
               </div>
             </div>
           </div>
         </div>
-        <footer
-          style={{
-            padding: '14px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            gap: 10,
-            justifyContent: 'flex-end',
-          }}
-        >
+        <footer className="px-5 py-3.5 border-t border-border flex gap-2.5 justify-end">
           <Button
             type="button"
             variant="ghost"
             size="md"
             onClick={onClose}
             disabled={loading}
-            style={{ color: 'var(--fg)', fontWeight: 600 }}
+            className="text-fg font-semibold"
           >
             {cancelLabel}
           </Button>
@@ -110,14 +79,9 @@ export function ConfirmDialog({
             size="md"
             onClick={onConfirm}
             disabled={loading}
-            style={
+            className={
               danger
-                ? {
-                    background: 'var(--destructive)',
-                    color: 'var(--destructive-fg)',
-                    borderColor: 'var(--destructive)',
-                    boxShadow: 'var(--shadow-xs)',
-                  }
+                ? 'bg-destructive text-destructive-fg border-destructive shadow-xs'
                 : undefined
             }
           >

--- a/ui/src/components/browse/FilterBar.tsx
+++ b/ui/src/components/browse/FilterBar.tsx
@@ -1,5 +1,6 @@
 import { I } from '@/components/icons'
 import type { RoomRowData, SidebarFilter, TagRowData } from '@/lib/types'
+import { cn } from '@/lib/utils'
 
 type SortKey = 'newest' | 'oldest' | 'longest'
 
@@ -39,85 +40,31 @@ export function FilterBar({
   if (filter.kind === 'recent') label = 'Recent (last 7 days)'
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 14,
-        padding: '10px 20px',
-        borderBottom: '1px solid var(--border)',
-        background: 'var(--card)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 12,
-      }}
-    >
-      <span style={{ color: 'var(--fg)', fontWeight: 600 }}>{label}</span>
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--fg-muted)',
-        }}
-      >
+    <div className="flex items-center gap-3.5 px-5 py-2.5 border-b border-border bg-card font-sans text-xs">
+      <span className="text-fg font-semibold">{label}</span>
+      <span className="font-mono text-[11px] text-fg-muted">
         {total} {total === 1 ? 'result' : 'results'}
       </span>
-      <div
-        style={{
-          marginLeft: 12,
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 8,
-          height: 30,
-          padding: '0 10px',
-          background: 'var(--bg)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-md)',
-          width: 320,
-          maxWidth: '40%',
-        }}
-      >
-        <span style={{ color: 'var(--fg-muted)', display: 'inline-flex' }}>{I.Search(13)}</span>
+      <div className="ml-3 inline-flex items-center gap-2 h-[30px] px-2.5 bg-bg border border-border rounded-md w-80 max-w-[40%]">
+        <span className="text-fg-muted inline-flex">{I.Search(13)}</span>
         <input
           value={query || ''}
           onChange={(e) => onSearch(e.target.value)}
           placeholder="Search transcripts, speakers, rooms…"
-          style={{
-            border: 'none',
-            outline: 'none',
-            background: 'transparent',
-            fontFamily: 'var(--font-sans)',
-            fontSize: 12.5,
-            color: 'var(--fg)',
-            flex: 1,
-          }}
+          className="border-none outline-none bg-transparent font-sans text-[12.5px] text-fg flex-1"
         />
         <span className="rf-kbd">⌘K</span>
       </div>
-      <div style={{ flex: 1 }} />
-      <span
-        style={{
-          color: 'var(--fg-muted)',
-          fontSize: 11,
-          fontFamily: 'var(--font-mono)',
-        }}
-      >
-        sort
-      </span>
+      <div className="flex-1" />
+      <span className="text-fg-muted text-[11px] font-mono">sort</span>
       {(['newest', 'oldest', 'longest'] as const).map((s) => (
         <button
           key={s}
           onClick={() => onSort(s)}
-          style={{
-            border: 'none',
-            padding: '3px 8px',
-            fontFamily: 'var(--font-sans)',
-            fontSize: 12,
-            cursor: 'pointer',
-            color: sort === s ? 'var(--fg)' : 'var(--fg-muted)',
-            fontWeight: sort === s ? 600 : 500,
-            borderRadius: 'var(--radius-sm)',
-            background: sort === s ? 'var(--muted)' : 'transparent',
-          }}
+          className={cn(
+            'border-none px-2 py-[3px] font-sans text-xs cursor-pointer rounded-sm',
+            sort === s ? 'text-fg font-semibold bg-muted' : 'text-fg-muted font-medium bg-transparent',
+          )}
         >
           {s}
         </button>

--- a/ui/src/components/browse/Pagination.tsx
+++ b/ui/src/components/browse/Pagination.tsx
@@ -1,5 +1,6 @@
 import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
+import { cn } from '@/lib/utils'
 
 type Props = {
   page: number
@@ -15,22 +16,11 @@ export function Pagination({ page, total, pageSize, onPage }: Props) {
   const end = Math.min(total, page * pageSize)
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '14px 20px',
-        borderTop: '1px solid var(--border)',
-        background: 'var(--card)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 12,
-      }}
-    >
-      <span style={{ color: 'var(--fg-muted)', fontFamily: 'var(--font-mono)' }}>
+    <div className="flex items-center justify-between px-5 py-3.5 border-t border-border bg-card font-sans text-xs">
+      <span className="text-fg-muted font-mono">
         {start}–{end} of {total}
       </span>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+      <div className="flex items-center gap-1">
         <Button
           variant="outline"
           size="sm"
@@ -43,19 +33,12 @@ export function Pagination({ page, total, pageSize, onPage }: Props) {
           <button
             key={n}
             onClick={() => onPage(n)}
-            style={{
-              width: 30,
-              height: 30,
-              borderRadius: 'var(--radius-md)',
-              cursor: 'pointer',
-              border: '1px solid',
-              borderColor: n === page ? 'var(--primary)' : 'var(--border)',
-              background: n === page ? 'var(--primary)' : 'var(--card)',
-              color: n === page ? 'var(--primary-fg)' : 'var(--fg)',
-              fontFamily: 'var(--font-sans)',
-              fontSize: 12,
-              fontWeight: 500,
-            }}
+            className={cn(
+              'w-[30px] h-[30px] rounded-md cursor-pointer border font-sans text-xs font-medium',
+              n === page
+                ? 'border-primary bg-primary text-primary-fg'
+                : 'border-border bg-card text-fg',
+            )}
           >
             {n}
           </button>

--- a/ui/src/components/browse/TranscriptRow.tsx
+++ b/ui/src/components/browse/TranscriptRow.tsx
@@ -3,6 +3,7 @@ import { I } from '@/components/icons'
 import { RowMenuTrigger } from '@/components/ui/primitives'
 import { fmtDate, fmtDur } from '@/lib/format'
 import type { TranscriptRowData } from '@/lib/types'
+import { cn } from '@/lib/utils'
 
 type Props = {
   t: TranscriptRowData
@@ -25,35 +26,25 @@ const STATUS_MAP: Record<string, ApiStatus> = {
   idle: 'idle',
 }
 
-function statusIconFor(apiStatus: ApiStatus): { node: ReactNode; color: string } {
+function statusIconFor(apiStatus: ApiStatus): { node: ReactNode; colorClass: string } {
   switch (apiStatus) {
     case 'recording':
-      return { node: I.Radio(14), color: 'var(--status-live)' }
+      return { node: I.Radio(14), colorClass: 'text-status-live' }
     case 'processing':
       return {
         node: (
-          <span
-            style={{
-              width: 12,
-              height: 12,
-              borderRadius: 9999,
-              display: 'inline-block',
-              border: '2px solid color-mix(in oklch, var(--status-processing) 25%, transparent)',
-              borderTopColor: 'var(--status-processing)',
-              animation: 'rfSpin 0.9s linear infinite',
-            }}
-          />
+          <span className="inline-block w-3 h-3 rounded-full border-2 border-[color-mix(in_oklch,var(--status-processing)_25%,transparent)] border-t-status-processing animate-[rfSpin_0.9s_linear_infinite]" />
         ),
-        color: 'var(--status-processing)',
+        colorClass: 'text-status-processing',
       }
     case 'uploaded':
-      return { node: I.Clock(14), color: 'var(--fg-muted)' }
+      return { node: I.Clock(14), colorClass: 'text-fg-muted' }
     case 'error':
-      return { node: I.AlertTriangle(14), color: 'var(--destructive)' }
+      return { node: I.AlertTriangle(14), colorClass: 'text-destructive' }
     case 'ended':
-      return { node: I.CheckCircle(14), color: 'var(--status-ok)' }
+      return { node: I.CheckCircle(14), colorClass: 'text-status-ok' }
     default:
-      return { node: I.Clock(14), color: 'var(--fg-muted)' }
+      return { node: I.Clock(14), colorClass: 'text-fg-muted' }
   }
 }
 
@@ -91,14 +82,7 @@ function Highlight({ text, query }: { text: string; query?: string }) {
   return (
     <>
       {text.slice(0, i)}
-      <mark
-        style={{
-          background: 'var(--reflector-accent-tint2)',
-          color: 'var(--fg)',
-          padding: '0 2px',
-          borderRadius: 2,
-        }}
-      >
+      <mark className="bg-[var(--reflector-accent-tint2)] text-fg px-0.5 py-0 rounded-[2px]">
         {text.slice(i, i + query.length)}
       </mark>
       {text.slice(i + query.length)}
@@ -116,7 +100,6 @@ export function TranscriptRow({
   onReprocess,
 }: Props) {
   const compact = density === 'compact'
-  const vpad = compact ? 10 : 14
   const apiStatus = STATUS_MAP[t.status] ?? 'idle'
   const statusIcon = statusIconFor(apiStatus)
   const sourceLabel = t.source === 'room' ? t.room || 'room' : t.source
@@ -131,81 +114,40 @@ export function TranscriptRow({
 
   return (
     <div
-      className="rf-row"
+      className={cn(
+        'rf-row grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3.5 px-5 border-b border-border cursor-pointer relative',
+        compact ? 'py-2.5' : 'py-3.5',
+      )}
       data-active={active ? 'true' : undefined}
       onClick={() => onSelect?.(t.id)}
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto auto',
-        alignItems: 'center',
-        columnGap: 14,
-        padding: `${vpad}px 20px`,
-        borderBottom: '1px solid var(--border)',
-        cursor: 'pointer',
-        position: 'relative',
-      }}
     >
       {active && (
-        <span
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: 6,
-            bottom: 6,
-            width: 2,
-            background: 'var(--primary)',
-            borderRadius: 2,
-          }}
-        />
+        <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 bg-primary rounded-[2px]" />
       )}
 
-      <span style={{ color: statusIcon.color, display: 'inline-flex' }}>{statusIcon.node}</span>
+      <span className={cn('inline-flex', statusIcon.colorClass)}>{statusIcon.node}</span>
 
-      <div
-        style={{
-          minWidth: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: compact ? 2 : 4,
-        }}
-      >
+      <div className={cn('min-w-0 flex flex-col', compact ? 'gap-0.5' : 'gap-1')}>
         <span
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: compact ? 14 : 15,
-            fontWeight: 600,
-            color: 'var(--fg)',
-            letterSpacing: '-0.005em',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
+          className={cn(
+            'font-serif font-semibold text-fg tracking-[-0.005em] whitespace-nowrap overflow-hidden text-ellipsis',
+            compact ? 'text-sm' : 'text-[15px]',
+          )}
         >
           <Highlight text={t.title || 'Unnamed transcript'} query={query} />
         </span>
 
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            rowGap: 2,
-            columnGap: 0,
-            fontSize: 11.5,
-            color: 'var(--fg-muted)',
-            fontFamily: 'var(--font-sans)',
-          }}
-        >
+        <div className="flex items-center flex-wrap gap-y-0.5 gap-x-0 text-[11.5px] text-fg-muted font-sans">
           <span>{sourceLabel}</span>
-          <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{fmtDate(t.date)}</span>
-          <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{fmtDur(t.duration)}</span>
+          <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+          <span className="font-mono text-[11px]">{fmtDate(t.date)}</span>
+          <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+          <span className="font-mono text-[11px]">{fmtDur(t.duration)}</span>
 
           {t.speakers > 0 && (
             <>
-              <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+              <span className="inline-flex items-center gap-1">
                 {I.Users(11)} {t.speakers} {t.speakers === 1 ? 'speaker' : 'speakers'}
               </span>
             </>
@@ -213,23 +155,15 @@ export function TranscriptRow({
 
           {srcLang && (
             <>
-              <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
+              <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
               <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  color: tgtLang ? 'var(--primary)' : 'var(--fg-muted)',
-                }}
+                className={cn(
+                  'inline-flex items-center gap-1',
+                  tgtLang ? 'text-primary' : 'text-fg-muted',
+                )}
               >
                 {I.Globe(11)}
-                <span
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 10.5,
-                    textTransform: 'uppercase',
-                  }}
-                >
+                <span className="font-mono text-[10.5px] uppercase">
                   {srcLang}
                   {tgtLang && <> → {tgtLang}</>}
                 </span>
@@ -239,42 +173,14 @@ export function TranscriptRow({
         </div>
 
         {errorMsg && (
-          <div
-            style={{
-              marginTop: 4,
-              padding: '6px 10px',
-              fontSize: 11.5,
-              lineHeight: 1.45,
-              fontFamily: 'var(--font-sans)',
-              color: 'var(--destructive)',
-              background: 'color-mix(in oklch, var(--destructive) 8%, transparent)',
-              border: '1px solid color-mix(in oklch, var(--destructive) 20%, transparent)',
-              borderRadius: 'var(--radius-sm)',
-              display: 'flex',
-              alignItems: 'flex-start',
-              gap: 6,
-            }}
-          >
-            <span style={{ marginTop: 1, flexShrink: 0 }}>{I.AlertTriangle(11)}</span>
-            <span style={{ minWidth: 0 }}>{errorMsg}</span>
+          <div className="mt-1 px-2.5 py-1.5 text-[11.5px] leading-[1.45] font-sans text-destructive bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] border border-[color-mix(in_oklch,var(--destructive)_20%,transparent)] rounded-sm flex items-start gap-1.5">
+            <span className="mt-px shrink-0">{I.AlertTriangle(11)}</span>
+            <span className="min-w-0">{errorMsg}</span>
           </div>
         )}
 
         {snippet && (
-          <div
-            style={{
-              marginTop: 4,
-              padding: '6px 10px',
-              fontSize: 12,
-              fontFamily: 'var(--font-serif)',
-              fontStyle: 'italic',
-              color: 'var(--fg-muted)',
-              lineHeight: 1.5,
-              background: 'var(--muted)',
-              borderLeft: '2px solid var(--primary)',
-              borderRadius: '0 var(--radius-sm) var(--radius-sm) 0',
-            }}
-          >
+          <div className="mt-1 px-2.5 py-1.5 text-xs font-serif italic text-fg-muted leading-[1.5] bg-muted border-l-2 border-primary rounded-r-sm">
             “<Highlight text={snippet} query={query} />”
           </div>
         )}
@@ -282,21 +188,7 @@ export function TranscriptRow({
 
       <span>
         {matchCount > 0 && (
-          <span
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              padding: '1px 8px',
-              height: 18,
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10.5,
-              fontWeight: 600,
-              color: 'var(--primary)',
-              background: 'var(--reflector-accent-tint)',
-              border: '1px solid var(--reflector-accent-tint2)',
-              borderRadius: 9999,
-            }}
-          >
+          <span className="inline-flex items-center px-2 py-px h-[18px] font-mono text-[10.5px] font-semibold text-primary bg-[var(--reflector-accent-tint)] border border-[var(--reflector-accent-tint2)] rounded-full">
             {matchCount} match
           </span>
         )}

--- a/ui/src/components/browse/TrashRow.tsx
+++ b/ui/src/components/browse/TrashRow.tsx
@@ -13,67 +13,27 @@ export function TrashRow({ t, onRestore, onDestroy }: Props) {
   const sourceLabel = t.source === 'room' ? t.room || 'room' : t.source
   return (
     <div
-      className="rf-row"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
-        alignItems: 'center',
-        columnGap: 14,
-        padding: '14px 20px',
-        borderBottom: '1px solid var(--border)',
-        cursor: 'default',
-        position: 'relative',
-        opacity: 0.78,
-        background:
-          'repeating-linear-gradient(45deg, transparent 0 12px, color-mix(in oklch, var(--muted) 40%, transparent) 12px 13px)',
-      }}
+      className="rf-row grid grid-cols-[auto_1fr_auto] items-center gap-x-3.5 px-5 py-3.5 border-b border-border cursor-default relative opacity-75 bg-[repeating-linear-gradient(45deg,transparent_0_12px,color-mix(in_oklch,var(--muted)_40%,transparent)_12px_13px)]"
     >
-      <span style={{ color: 'var(--fg-muted)', display: 'inline-flex' }}>{I.Trash(14)}</span>
+      <span className="text-fg-muted inline-flex">{I.Trash(14)}</span>
 
-      <div style={{ minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
-        <span
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 15,
-            fontWeight: 500,
-            color: 'var(--fg-muted)',
-            letterSpacing: '-0.005em',
-            textDecoration: 'line-through',
-            textDecorationColor: 'color-mix(in oklch, var(--fg-muted) 50%, transparent)',
-            textDecorationThickness: '1px',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
+      <div className="min-w-0 flex flex-col gap-1">
+        <span className="font-serif text-[15px] font-medium text-fg-muted tracking-[-0.005em] line-through decoration-[color-mix(in_oklch,var(--fg-muted)_50%,transparent)] decoration-1 whitespace-nowrap overflow-hidden text-ellipsis">
           {t.title || 'Unnamed transcript'}
         </span>
 
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            rowGap: 2,
-            columnGap: 0,
-            fontSize: 11.5,
-            color: 'var(--fg-muted)',
-            fontFamily: 'var(--font-sans)',
-          }}
-        >
+        <div className="flex items-center flex-wrap gap-y-0.5 gap-x-0 text-[11.5px] text-fg-muted font-sans">
           <span>{sourceLabel}</span>
-          <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{fmtDate(t.date)}</span>
+          <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+          <span className="font-mono text-[11px]">{fmtDate(t.date)}</span>
           {t.duration > 0 && (
             <>
-              <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
-                {fmtDur(t.duration)}
-              </span>
+              <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+              <span className="font-mono text-[11px]">{fmtDur(t.duration)}</span>
             </>
           )}
-          <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
+          <span className="inline-flex items-center gap-1">
             {I.Trash(11)} Deleted
           </span>
         </div>

--- a/ui/src/components/home/LanguagePair.tsx
+++ b/ui/src/components/home/LanguagePair.tsx
@@ -1,4 +1,5 @@
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { REFLECTOR_LANGS } from '@/lib/types'
 
 type Props = {
@@ -18,12 +19,10 @@ export function LanguagePair({
 }: Props) {
   return (
     <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: horizontal ? '1fr auto 1fr' : '1fr',
-        gap: horizontal ? 8 : 14,
-        alignItems: 'end',
-      }}
+      className={cn(
+        'grid items-end',
+        horizontal ? 'grid-cols-[1fr_auto_1fr] gap-2' : 'grid-cols-1 gap-3.5',
+      )}
     >
       <div>
         <label className="rf-label" htmlFor="rf-source-lang">
@@ -31,10 +30,9 @@ export function LanguagePair({
         </label>
         <select
           id="rf-source-lang"
-          className="rf-select"
+          className="rf-select mt-1.5"
           value={sourceLang}
           onChange={(e) => setSourceLang(e.target.value)}
-          style={{ marginTop: 6 }}
         >
           {REFLECTOR_LANGS.map((l) => (
             <option key={l.code} value={l.code}>
@@ -54,19 +52,7 @@ export function LanguagePair({
             setTargetLang(a)
           }}
           title="Swap languages"
-          style={{
-            height: 40,
-            width: 40,
-            marginBottom: 18,
-            border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-md)',
-            background: 'var(--muted)',
-            cursor: 'pointer',
-            color: 'var(--fg-muted)',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          className="h-10 w-10 mb-[18px] border border-border rounded-md bg-muted cursor-pointer text-fg-muted inline-flex items-center justify-center"
         >
           {I.Swap(16)}
         </button>
@@ -78,10 +64,9 @@ export function LanguagePair({
         </label>
         <select
           id="rf-target-lang"
-          className="rf-select"
+          className="rf-select mt-1.5"
           value={targetLang}
           onChange={(e) => setTargetLang(e.target.value)}
-          style={{ marginTop: 6 }}
         >
           <option value="">— None (same as spoken) —</option>
           {REFLECTOR_LANGS.map((l) => (

--- a/ui/src/components/home/RoomPicker.tsx
+++ b/ui/src/components/home/RoomPicker.tsx
@@ -12,14 +12,13 @@ export function RoomPicker({ roomId, setRoomId, rooms }: Props) {
     <div>
       <label className="rf-label" htmlFor="rf-room">
         {I.Folder(13)} Attach to room{' '}
-        <span style={{ color: 'var(--fg-muted)', fontWeight: 400 }}>— optional</span>
+        <span className="text-fg-muted font-normal">— optional</span>
       </label>
       <select
         id="rf-room"
-        className="rf-select"
+        className="rf-select mt-1.5"
         value={roomId}
         onChange={(e) => setRoomId(e.target.value)}
-        style={{ marginTop: 6 }}
       >
         <option value="">— None —</option>
         {rooms.map((r) => (

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -10,25 +10,11 @@ type AppShellProps = {
 
 export function AppShell({ title, crumb, sidebar, children }: AppShellProps) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        height: '100vh',
-        background: 'var(--bg)',
-        overflow: 'hidden',
-      }}
-    >
+    <div className="flex h-screen bg-bg overflow-hidden">
       {sidebar}
-      <main style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+      <main className="flex-1 flex flex-col min-w-0">
         <TopBar title={title} crumb={crumb} />
-        <div
-          style={{
-            flex: 1,
-            overflowY: 'auto',
-            padding: 24,
-            background: 'var(--bg)',
-          }}
-        >
+        <div className="flex-1 overflow-y-auto p-6 bg-bg">
           {children}
         </div>
       </main>

--- a/ui/src/components/layout/AppSidebar.tsx
+++ b/ui/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import { Button, SectionLabel, SidebarItem } from '@/components/ui/primitives'
 import type { RoomRowData, SidebarFilter, TagRowData } from '@/lib/types'
 import { BrandHeader, PrimaryNav, UserChip, sidebarAsideStyle } from './sidebarChrome'
 import { useAuth } from '@/auth/AuthContext'
+import { cn } from '@/lib/utils'
 
 type AppSidebarProps = {
   filter: SidebarFilter
@@ -92,38 +93,23 @@ function ExpandedNav({
 
   return (
     <>
-      <div style={{ padding: '14px 12px 6px' }}>
+      <div className="pt-3.5 px-3 pb-1.5">
         <Button
           variant="primary"
           size="md"
-          style={{ width: '100%', justifyContent: 'flex-start' }}
+          className="w-full justify-start"
           onClick={onNewRecording}
         >
           {I.Mic(14)} New recording
         </Button>
       </div>
 
-      <nav
-        style={{
-          flex: 1,
-          padding: '6px 10px 12px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 14,
-          overflowY: 'auto',
-        }}
-      >
+      <nav className="flex-1 pt-1.5 px-2.5 pb-3 flex flex-col gap-3.5 overflow-y-auto">
         <PrimaryNav />
 
-        <div
-          style={{
-            height: 1,
-            background: 'var(--border)',
-            margin: '2px 6px',
-          }}
-        />
+        <div className="h-px bg-border mx-1.5 my-0.5" />
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <div className="flex flex-col gap-px">
           <SidebarItem
             icon={I.Inbox(15)}
             label="All transcripts"
@@ -141,7 +127,7 @@ function ExpandedNav({
 
         <div>
           <SectionLabel>Sources</SectionLabel>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <div className="flex flex-col gap-px">
             <SidebarItem
               icon={I.Radio(15)}
               label="Live transcripts"
@@ -168,12 +154,12 @@ function ExpandedNav({
           <div>
             <SectionLabel
               action={
-                <span style={{ color: 'var(--fg-muted)', cursor: 'pointer', opacity: 0.6 }}>+</span>
+                <span className="text-fg-muted cursor-pointer opacity-60">+</span>
               }
             >
               My rooms
             </SectionLabel>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <div className="flex flex-col gap-px">
               {myRooms.map((r) => (
                 <SidebarItem
                   key={r.id}
@@ -191,7 +177,7 @@ function ExpandedNav({
         {sharedRooms.length > 0 && (
           <div>
             <SectionLabel>Shared</SectionLabel>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <div className="flex flex-col gap-px">
               {sharedRooms.map((r) => (
                 <SidebarItem
                   key={r.id}
@@ -210,12 +196,12 @@ function ExpandedNav({
           <div>
             <SectionLabel
               action={
-                <span style={{ color: 'var(--fg-muted)', cursor: 'pointer', opacity: 0.6 }}>+</span>
+                <span className="text-fg-muted cursor-pointer opacity-60">+</span>
               }
             >
               Tags
             </SectionLabel>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <div className="flex flex-col gap-px">
               {tags.map((t) => (
                 <SidebarItem
                   key={t.id}
@@ -230,7 +216,7 @@ function ExpandedNav({
           </div>
         )}
 
-        <div style={{ marginTop: 'auto', borderTop: '1px solid var(--border)', paddingTop: 10 }}>
+        <div className="mt-auto border-t border-border pt-2.5">
           <SidebarItem
             icon={I.Trash(15)}
             label="Trash"
@@ -265,20 +251,11 @@ function CollapsedRail({ filter, onFilter, onToggle, onNewRecording }: Collapsed
     { kind: 'trash', icon: I.Trash(18), title: 'Trash' },
   ]
   return (
-    <nav
-      style={{
-        flex: 1,
-        padding: '10px 8px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 4,
-        alignItems: 'center',
-      }}
-    >
+    <nav className="flex-1 py-2.5 px-2 flex flex-col gap-1 items-center">
       <Button variant="primary" size="icon" title="New recording" onClick={onNewRecording}>
         {I.Mic(16)}
       </Button>
-      <div style={{ height: 10 }} />
+      <div className="h-2.5" />
       {items.map((it, i) => {
         const on = filter.kind === it.kind && (filter.value ?? null) === (it.value ?? null)
         return (
@@ -288,40 +265,22 @@ function CollapsedRail({ filter, onFilter, onToggle, onNewRecording }: Collapsed
             onClick={() =>
               onFilter({ kind: it.kind, value: (it.value ?? null) as never } as SidebarFilter)
             }
-            style={{
-              width: 40,
-              height: 40,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              border: '1px solid',
-              borderColor: on ? 'var(--border)' : 'transparent',
-              borderRadius: 'var(--radius-md)',
-              background: on ? 'var(--card)' : 'transparent',
-              color: on ? 'var(--primary)' : 'var(--fg-muted)',
-              cursor: 'pointer',
-              boxShadow: on ? 'var(--shadow-xs)' : 'none',
-            }}
+            className={cn(
+              'w-10 h-10 inline-flex items-center justify-center border rounded-md cursor-pointer',
+              on
+                ? 'border-border bg-card text-primary shadow-xs'
+                : 'border-transparent bg-transparent text-fg-muted shadow-none',
+            )}
           >
             {it.icon}
           </button>
         )
       })}
-      <div style={{ marginTop: 'auto' }}>
+      <div className="mt-auto">
         <button
           onClick={onToggle}
           title="Expand sidebar"
-          style={{
-            width: 40,
-            height: 40,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            border: 'none',
-            background: 'transparent',
-            color: 'var(--fg-muted)',
-            cursor: 'pointer',
-          }}
+          className="w-10 h-10 inline-flex items-center justify-center border-none bg-transparent text-fg-muted cursor-pointer"
         >
           {I.ChevronRight(16)}
         </button>

--- a/ui/src/components/layout/MinimalHeader.tsx
+++ b/ui/src/components/layout/MinimalHeader.tsx
@@ -16,101 +16,39 @@ type Props = {
  */
 export function MinimalHeader({ title, crumb, actions }: Props) {
   return (
-    <header
-      style={{
-        height: 56,
-        background: 'var(--card)',
-        borderBottom: '1px solid var(--border)',
-        display: 'flex',
-        alignItems: 'center',
-        padding: '0 20px',
-        gap: 14,
-        fontFamily: 'var(--font-sans)',
-        flexShrink: 0,
-      }}
-    >
-      <Link
-        to="/"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          textDecoration: 'none',
-          color: 'var(--fg)',
-        }}
-      >
+    <header className="h-14 bg-card border-b border-border flex items-center px-5 gap-3.5 font-sans shrink-0">
+      <Link to="/" className="flex items-center gap-2.5 no-underline text-fg">
         <ReflectorMark size={24} />
-        <span
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 16,
-            fontWeight: 600,
-            letterSpacing: '-0.01em',
-          }}
-        >
+        <span className="font-serif text-base font-semibold tracking-[-0.01em]">
           Reflector
         </span>
       </Link>
 
       {(title || (crumb && crumb.length > 0)) && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 1,
-            marginLeft: 14,
-            paddingLeft: 14,
-            borderLeft: '1px solid var(--border)',
-            minWidth: 0,
-          }}
-        >
+        <div className="flex flex-col gap-px ml-3.5 pl-3.5 border-l border-border min-w-0">
           {crumb && crumb.length > 0 && (
-            <div
-              style={{
-                fontSize: 11,
-                color: 'var(--fg-muted)',
-                display: 'flex',
-                gap: 6,
-                alignItems: 'center',
-                fontFamily: 'var(--font-mono)',
-              }}
-            >
+            <div className="text-[11px] text-fg-muted flex gap-1.5 items-center font-mono">
               {crumb.map((c, i) => (
                 <Fragment key={i}>
-                  <span
-                    style={{
-                      color: i === crumb.length - 1 ? 'var(--fg)' : 'var(--fg-muted)',
-                    }}
-                  >
+                  <span className={i === crumb.length - 1 ? 'text-fg' : 'text-fg-muted'}>
                     {c}
                   </span>
                   {i < crumb.length - 1 && (
-                    <span style={{ color: 'var(--gh-grey-4)' }}>/</span>
+                    <span className="text-[var(--gh-grey-4)]">/</span>
                   )}
                 </Fragment>
               ))}
             </div>
           )}
           {title && (
-            <div
-              style={{
-                fontFamily: 'var(--font-serif)',
-                fontSize: 15,
-                fontWeight: 600,
-                letterSpacing: '-0.015em',
-                color: 'var(--fg)',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
+            <div className="font-serif text-[15px] font-semibold tracking-[-0.015em] text-fg whitespace-nowrap overflow-hidden text-ellipsis">
               {title}
             </div>
           )}
         </div>
       )}
 
-      <div style={{ flex: 1 }} />
+      <div className="flex-1" />
 
       {actions}
       <ThemeToggle />

--- a/ui/src/components/layout/PublicShell.tsx
+++ b/ui/src/components/layout/PublicShell.tsx
@@ -18,109 +18,40 @@ type PublicShellProps = {
 export function PublicShell({ title, crumb, children }: PublicShellProps) {
   const { authenticated } = useAuth()
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        background: 'var(--bg)',
-      }}
-    >
-      <header
-        style={{
-          height: 65,
-          background: 'var(--card)',
-          borderBottom: '1px solid var(--border)',
-          display: 'flex',
-          alignItems: 'center',
-          padding: '0 24px',
-          gap: 16,
-          fontFamily: 'var(--font-sans)',
-          flexShrink: 0,
-        }}
-      >
-        <Link
-          to="/"
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            textDecoration: 'none',
-            color: 'var(--fg)',
-          }}
-        >
+    <div className="flex flex-col min-h-screen bg-bg">
+      <header className="h-[65px] bg-card border-b border-border flex items-center px-6 gap-4 font-sans shrink-0">
+        <Link to="/" className="flex items-center gap-2.5 no-underline text-fg">
           <ReflectorMark size={26} />
-          <span
-            style={{
-              fontFamily: 'var(--font-serif)',
-              fontSize: 17,
-              fontWeight: 600,
-              letterSpacing: '-0.01em',
-            }}
-          >
+          <span className="font-serif text-[17px] font-semibold tracking-[-0.01em]">
             Reflector
           </span>
         </Link>
 
         {(title || (crumb && crumb.length > 0)) && (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 1,
-              marginLeft: 18,
-              paddingLeft: 18,
-              borderLeft: '1px solid var(--border)',
-              minWidth: 0,
-            }}
-          >
+          <div className="flex flex-col gap-px ml-[18px] pl-[18px] border-l border-border min-w-0">
             {crumb && crumb.length > 0 && (
-              <div
-                style={{
-                  fontSize: 11,
-                  color: 'var(--fg-muted)',
-                  display: 'flex',
-                  gap: 6,
-                  alignItems: 'center',
-                  fontFamily: 'var(--font-mono)',
-                }}
-              >
+              <div className="text-[11px] text-fg-muted flex gap-1.5 items-center font-mono">
                 {crumb.map((c, i) => (
                   <Fragment key={i}>
-                    <span
-                      style={{
-                        color: i === crumb.length - 1 ? 'var(--fg)' : 'var(--fg-muted)',
-                      }}
-                    >
+                    <span className={i === crumb.length - 1 ? 'text-fg' : 'text-fg-muted'}>
                       {c}
                     </span>
                     {i < crumb.length - 1 && (
-                      <span style={{ color: 'var(--gh-grey-4)' }}>/</span>
+                      <span className="text-[var(--gh-grey-4)]">/</span>
                     )}
                   </Fragment>
                 ))}
               </div>
             )}
             {title && (
-              <div
-                style={{
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 16,
-                  fontWeight: 600,
-                  letterSpacing: '-0.015em',
-                  color: 'var(--fg)',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
+              <div className="font-serif text-base font-semibold tracking-[-0.015em] text-fg whitespace-nowrap overflow-hidden text-ellipsis">
                 {title}
               </div>
             )}
           </div>
         )}
 
-        <div style={{ flex: 1 }} />
+        <div className="flex-1" />
 
         <ThemeToggle />
 
@@ -131,32 +62,14 @@ export function PublicShell({ title, crumb, children }: PublicShellProps) {
                 ? window.location.pathname + window.location.search
                 : '/',
             )}`}
-            style={{
-              fontFamily: 'var(--font-sans)',
-              fontSize: 13,
-              fontWeight: 500,
-              color: 'var(--fg)',
-              textDecoration: 'none',
-              padding: '6px 12px',
-              borderRadius: 'var(--radius-md)',
-              border: '1px solid var(--border)',
-              background: 'var(--card)',
-              boxShadow: 'var(--shadow-xs)',
-            }}
+            className="font-sans text-[13px] font-medium text-fg no-underline py-1.5 px-3 rounded-md border border-border bg-card shadow-xs"
           >
             Sign in
           </Link>
         )}
       </header>
 
-      <main
-        style={{
-          flex: 1,
-          padding: '24px',
-          width: '100%',
-          boxSizing: 'border-box',
-        }}
-      >
+      <main className="flex-1 p-6 w-full box-border">
         {children}
       </main>
     </div>

--- a/ui/src/components/layout/ReflectorMark.tsx
+++ b/ui/src/components/layout/ReflectorMark.tsx
@@ -5,7 +5,7 @@ export function ReflectorMark({ size = 28 }: { size?: number }) {
       height={size}
       viewBox="0 0 500 500"
       aria-hidden="true"
-      style={{ display: 'block', flexShrink: 0 }}
+      className="block shrink-0"
     >
       <polygon
         points="227.5,51.5 86.5,150.1 100.8,383.9 244.3,249.8"

--- a/ui/src/components/layout/RoomsSidebar.tsx
+++ b/ui/src/components/layout/RoomsSidebar.tsx
@@ -5,6 +5,7 @@ import { Button, SectionLabel, SidebarItem } from '@/components/ui/primitives'
 import type { RoomsFilter } from '@/lib/types'
 import { BrandHeader, PrimaryNav, UserChip, sidebarAsideStyle } from './sidebarChrome'
 import { useAuth } from '@/auth/AuthContext'
+import { cn } from '@/lib/utils'
 
 type Room = components['schemas']['RoomDetails']
 
@@ -66,38 +67,23 @@ export function RoomsSidebar({
         />
       ) : (
         <>
-          <div style={{ padding: '14px 12px 6px' }}>
+          <div className="pt-3.5 px-3 pb-1.5">
             <Button
               variant="primary"
               size="md"
-              style={{ width: '100%', justifyContent: 'flex-start' }}
+              className="w-full justify-start"
               onClick={onNewRecording}
             >
               {I.Mic(14)} New recording
             </Button>
           </div>
 
-          <nav
-            style={{
-              flex: 1,
-              padding: '6px 10px 12px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 14,
-              overflowY: 'auto',
-            }}
-          >
+          <nav className="flex-1 pt-1.5 px-2.5 pb-3 flex flex-col gap-3.5 overflow-y-auto">
             <PrimaryNav />
 
-            <div
-              style={{
-                height: 1,
-                background: 'var(--border)',
-                margin: '2px 6px',
-              }}
-            />
+            <div className="h-px bg-border mx-1.5 my-0.5" />
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <div className="flex flex-col gap-px">
               <SidebarItem
                 icon={I.Door(15)}
                 label="All rooms"
@@ -123,7 +109,7 @@ export function RoomsSidebar({
 
             <div>
               <SectionLabel>Status</SectionLabel>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <div className="flex flex-col gap-px">
                 <SidebarItem
                   icon={I.Radio(14)}
                   label="Active now"
@@ -145,19 +131,14 @@ export function RoomsSidebar({
             {presentPlatforms.length > 0 && (
               <div>
                 <SectionLabel>Platform</SectionLabel>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                <div className="flex flex-col gap-px">
                   {presentPlatforms.map((p) => (
                     <SidebarItem
                       key={p}
                       icon={
                         <span
-                          style={{
-                            width: 14,
-                            height: 14,
-                            borderRadius: 3,
-                            background: PLATFORM_COLOR[p],
-                            display: 'inline-block',
-                          }}
+                          className="w-3.5 h-3.5 rounded-[3px] inline-block"
+                          style={{ background: PLATFORM_COLOR[p] }}
                         />
                       }
                       label={p.charAt(0).toUpperCase() + p.slice(1)}
@@ -172,7 +153,7 @@ export function RoomsSidebar({
 
             <div>
               <SectionLabel>Size</SectionLabel>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <div className="flex flex-col gap-px">
                 <SidebarItem
                   icon={I.User(14)}
                   label="2–4 people"
@@ -192,7 +173,7 @@ export function RoomsSidebar({
 
             <div>
               <SectionLabel>Recording</SectionLabel>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <div className="flex flex-col gap-px">
                 <SidebarItem
                   icon={I.Cloud(14)}
                   label="Cloud"
@@ -246,20 +227,11 @@ function RoomsRail({ filter, onFilter, onToggle, onNewRecording }: RailProps) {
     { kind: 'status', value: 'calendar', icon: I.Calendar(18), title: 'Calendar' },
   ]
   return (
-    <nav
-      style={{
-        flex: 1,
-        padding: '10px 8px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 4,
-        alignItems: 'center',
-      }}
-    >
+    <nav className="flex-1 py-2.5 px-2 flex flex-col gap-1 items-center">
       <Button variant="primary" size="icon" title="New recording" onClick={onNewRecording}>
         {I.Mic(16)}
       </Button>
-      <div style={{ height: 10 }} />
+      <div className="h-2.5" />
       {items.map((it, i) => {
         const on =
           filter.kind === it.kind && (filter.value ?? null) === (it.value ?? null)
@@ -270,40 +242,22 @@ function RoomsRail({ filter, onFilter, onToggle, onNewRecording }: RailProps) {
             onClick={() =>
               onFilter({ kind: it.kind, value: it.value } as RoomsFilter)
             }
-            style={{
-              width: 40,
-              height: 40,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              border: '1px solid',
-              borderColor: on ? 'var(--border)' : 'transparent',
-              borderRadius: 'var(--radius-md)',
-              background: on ? 'var(--card)' : 'transparent',
-              color: on ? 'var(--primary)' : 'var(--fg-muted)',
-              cursor: 'pointer',
-              boxShadow: on ? 'var(--shadow-xs)' : 'none',
-            }}
+            className={cn(
+              'w-10 h-10 inline-flex items-center justify-center border rounded-md cursor-pointer',
+              on
+                ? 'border-border bg-card text-primary shadow-xs'
+                : 'border-transparent bg-transparent text-fg-muted shadow-none',
+            )}
           >
             {it.icon}
           </button>
         )
       })}
-      <div style={{ marginTop: 'auto' }}>
+      <div className="mt-auto">
         <button
           onClick={onToggle}
           title="Expand sidebar"
-          style={{
-            width: 40,
-            height: 40,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            border: 'none',
-            background: 'transparent',
-            color: 'var(--fg-muted)',
-            cursor: 'pointer',
-          }}
+          className="w-10 h-10 inline-flex items-center justify-center border-none bg-transparent text-fg-muted cursor-pointer"
         >
           {I.ChevronRight(16)}
         </button>

--- a/ui/src/components/layout/SettingsSidebar.tsx
+++ b/ui/src/components/layout/SettingsSidebar.tsx
@@ -4,6 +4,7 @@ import { I } from '@/components/icons'
 import { Button, SectionLabel, SidebarItem } from '@/components/ui/primitives'
 import { BrandHeader, PrimaryNav, UserChip, sidebarAsideStyle } from './sidebarChrome'
 import { useAuth } from '@/auth/AuthContext'
+import { cn } from '@/lib/utils'
 
 type SettingsNavItem = {
   id: string
@@ -39,40 +40,25 @@ export function SettingsSidebar({ collapsed, onToggle, onNewRecording }: Props) 
         <SettingsRail onToggle={onToggle} onNewRecording={onNewRecording} />
       ) : (
         <>
-          <div style={{ padding: '14px 12px 6px' }}>
+          <div className="pt-3.5 px-3 pb-1.5">
             <Button
               variant="primary"
               size="md"
-              style={{ width: '100%', justifyContent: 'flex-start' }}
+              className="w-full justify-start"
               onClick={onNewRecording}
             >
               {I.Mic(14)} New recording
             </Button>
           </div>
 
-          <nav
-            style={{
-              flex: 1,
-              padding: '6px 10px 12px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 14,
-              overflowY: 'auto',
-            }}
-          >
+          <nav className="flex-1 pt-1.5 px-2.5 pb-3 flex flex-col gap-3.5 overflow-y-auto">
             <PrimaryNav />
 
-            <div
-              style={{
-                height: 1,
-                background: 'var(--border)',
-                margin: '2px 6px',
-              }}
-            />
+            <div className="h-px bg-border mx-1.5 my-0.5" />
 
             <div>
               <SectionLabel>Settings</SectionLabel>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <div className="flex flex-col gap-px">
                 {SETTINGS_NAV.map((item) => (
                   <SidebarItem
                     key={item.id}
@@ -103,20 +89,11 @@ function SettingsRail({
   const navigate = useNavigate()
   const location = useLocation()
   return (
-    <nav
-      style={{
-        flex: 1,
-        padding: '10px 8px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 4,
-        alignItems: 'center',
-      }}
-    >
+    <nav className="flex-1 py-2.5 px-2 flex flex-col gap-1 items-center">
       <Button variant="primary" size="icon" title="New recording" onClick={onNewRecording}>
         {I.Mic(16)}
       </Button>
-      <div style={{ height: 10 }} />
+      <div className="h-2.5" />
       {SETTINGS_NAV.map((item) => {
         const on = location.pathname.startsWith(item.path)
         return (
@@ -124,40 +101,22 @@ function SettingsRail({
             key={item.id}
             title={item.label}
             onClick={() => navigate(item.path)}
-            style={{
-              width: 40,
-              height: 40,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              border: '1px solid',
-              borderColor: on ? 'var(--border)' : 'transparent',
-              borderRadius: 'var(--radius-md)',
-              background: on ? 'var(--card)' : 'transparent',
-              color: on ? 'var(--primary)' : 'var(--fg-muted)',
-              cursor: 'pointer',
-              boxShadow: on ? 'var(--shadow-xs)' : 'none',
-            }}
+            className={cn(
+              'w-10 h-10 inline-flex items-center justify-center border rounded-md cursor-pointer',
+              on
+                ? 'border-border bg-card text-primary shadow-xs'
+                : 'border-transparent bg-transparent text-fg-muted shadow-none',
+            )}
           >
             {item.icon}
           </button>
         )
       })}
-      <div style={{ marginTop: 'auto' }}>
+      <div className="mt-auto">
         <button
           onClick={onToggle}
           title="Expand sidebar"
-          style={{
-            width: 40,
-            height: 40,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            border: 'none',
-            background: 'transparent',
-            color: 'var(--fg-muted)',
-            cursor: 'pointer',
-          }}
+          className="w-10 h-10 inline-flex items-center justify-center border-none bg-transparent text-fg-muted cursor-pointer"
         >
           {I.ChevronRight(16)}
         </button>

--- a/ui/src/components/layout/TopBar.tsx
+++ b/ui/src/components/layout/TopBar.tsx
@@ -8,73 +8,30 @@ type TopBarProps = {
 
 export function TopBar({ title, crumb }: TopBarProps) {
   return (
-    <header
-      style={{
-        height: 65,
-        background: 'var(--card)',
-        borderBottom: '1px solid var(--border)',
-        display: 'flex',
-        alignItems: 'center',
-        padding: '0 24px',
-        gap: 16,
-        fontFamily: 'var(--font-sans)',
-        flexShrink: 0,
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 1,
-          alignSelf: 'flex-end',
-          paddingBottom: 10,
-          flexShrink: 0,
-        }}
-      >
+    <header className="h-[65px] bg-card border-b border-border flex items-center px-6 gap-4 font-sans shrink-0">
+      <div className="flex flex-col gap-px self-end pb-2.5 shrink-0">
         {crumb && crumb.length > 0 && (
-          <div
-            style={{
-              fontSize: 11,
-              color: 'var(--fg-muted)',
-              display: 'flex',
-              gap: 6,
-              alignItems: 'center',
-              fontFamily: 'var(--font-mono)',
-            }}
-          >
+          <div className="text-[11px] text-fg-muted flex gap-1.5 items-center font-mono">
             {crumb.map((c, i) => (
               <Fragment key={i}>
-                <span
-                  style={{
-                    color: i === crumb.length - 1 ? 'var(--fg)' : 'var(--fg-muted)',
-                  }}
-                >
+                <span className={i === crumb.length - 1 ? 'text-fg' : 'text-fg-muted'}>
                   {c}
                 </span>
                 {i < crumb.length - 1 && (
-                  <span style={{ color: 'var(--gh-grey-4)' }}>/</span>
+                  <span className="text-[var(--gh-grey-4)]">/</span>
                 )}
               </Fragment>
             ))}
           </div>
         )}
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
-          <h1
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 22,
-              fontWeight: 600,
-              letterSpacing: '-0.02em',
-              color: 'var(--fg)',
-            }}
-          >
+        <div className="flex items-baseline gap-2.5">
+          <h1 className="m-0 font-serif text-[22px] font-semibold tracking-[-0.02em] text-fg">
             {title}
           </h1>
         </div>
       </div>
 
-      <div style={{ flex: 1 }} />
+      <div className="flex-1" />
 
       <ThemeToggle />
     </header>

--- a/ui/src/components/layout/sidebarChrome.tsx
+++ b/ui/src/components/layout/sidebarChrome.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { I } from '@/components/icons'
 import { SidebarItem } from '@/components/ui/primitives'
 import { useAuth } from '@/auth/AuthContext'
+import { cn } from '@/lib/utils'
 import { ReflectorMark } from './ReflectorMark'
 
 /**
@@ -19,7 +20,7 @@ export function PrimaryNav() {
     location.pathname.startsWith('/transcript/')
   const onRooms = location.pathname.startsWith('/rooms')
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+    <div className="flex flex-col gap-px">
       <SidebarItem
         icon={I.Inbox(15)}
         label="Transcripts"
@@ -45,41 +46,22 @@ export function BrandHeader({
 }) {
   return (
     <div
-      style={{
-        height: 65,
-        display: 'flex',
-        alignItems: 'center',
-        padding: collapsed ? '0' : '0 16px',
-        justifyContent: collapsed ? 'center' : 'space-between',
-        borderBottom: '1px solid var(--border)',
-      }}
+      className={cn(
+        'h-[65px] flex items-center border-b border-border',
+        collapsed ? 'px-0 justify-center' : 'px-4 justify-between',
+      )}
     >
       {collapsed ? (
         <ReflectorMark size={28} />
       ) : (
         <>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div className="flex items-center gap-2.5">
             <ReflectorMark size={26} />
-            <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
-              <span
-                style={{
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 17,
-                  fontWeight: 600,
-                  letterSpacing: '-0.01em',
-                  color: 'var(--fg)',
-                }}
-              >
+            <div className="flex flex-col leading-none">
+              <span className="font-serif text-[17px] font-semibold tracking-[-0.01em] text-fg">
                 Reflector
               </span>
-              <span
-                style={{
-                  fontSize: 10,
-                  color: 'var(--fg-muted)',
-                  fontFamily: 'var(--font-mono)',
-                  marginTop: 2,
-                }}
-              >
+              <span className="text-[10px] text-fg-muted font-mono mt-0.5">
                 by Greyhaven
               </span>
             </div>
@@ -87,15 +69,7 @@ export function BrandHeader({
           <button
             onClick={onToggle}
             title="Collapse sidebar"
-            style={{
-              border: 'none',
-              background: 'transparent',
-              color: 'var(--fg-muted)',
-              cursor: 'pointer',
-              padding: 4,
-              borderRadius: 4,
-              display: 'inline-flex',
-            }}
+            className="border-none bg-transparent text-fg-muted cursor-pointer p-1 rounded-sm inline-flex"
           >
             {I.ChevronLeft(14)}
           </button>
@@ -137,24 +111,12 @@ export function UserChip({
   return (
     <div
       ref={wrapperRef}
-      style={{ borderTop: '1px solid var(--border)', padding: 12, position: 'relative' }}
+      className="border-t border-border p-3 relative"
     >
       {open && (
         <div
           role="menu"
-          style={{
-            position: 'absolute',
-            left: 12,
-            right: 12,
-            bottom: 'calc(100% - 6px)',
-            background: 'var(--card)',
-            border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-md)',
-            boxShadow: 'var(--shadow-md)',
-            padding: 4,
-            zIndex: 60,
-            fontFamily: 'var(--font-sans)',
-          }}
+          className="absolute left-3 right-3 bottom-[calc(100%-6px)] bg-card border border-border rounded-md shadow-md p-1 z-[60] font-sans"
         >
           <MenuRow
             icon={I.Settings(14)}
@@ -164,7 +126,7 @@ export function UserChip({
               navigate('/settings')
             }}
           />
-          <div style={{ height: 1, background: 'var(--border)', margin: '4px 2px' }} />
+          <div className="h-px bg-border mx-0.5 my-1" />
           <MenuRow
             icon={I.ExternalLink(14)}
             label="Log out"
@@ -180,65 +142,27 @@ export function UserChip({
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          padding: '8px 10px',
-          background: 'var(--card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-md)',
-          cursor: 'pointer',
-          fontFamily: 'var(--font-sans)',
-          boxShadow: 'var(--shadow-xs)',
-        }}
+        className="w-full flex items-center gap-2.5 px-2.5 py-2 bg-card border border-border rounded-md cursor-pointer font-sans shadow-xs"
       >
         <span
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 9999,
-            background: 'var(--gh-off-black)',
-            color: 'var(--gh-off-white)',
-            fontSize: 11,
-            fontWeight: 600,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          className="w-7 h-7 rounded-full text-[11px] font-semibold inline-flex items-center justify-center"
+          style={{ background: 'var(--gh-off-black)', color: 'var(--gh-off-white)' }}
         >
           {initials(displayName)}
         </span>
-        <span style={{ flex: 1, textAlign: 'left', minWidth: 0 }}>
-          <div
-            style={{
-              fontSize: 13,
-              fontWeight: 500,
-              color: 'var(--fg)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
+        <span className="flex-1 text-left min-w-0">
+          <div className="text-[13px] font-medium text-fg whitespace-nowrap overflow-hidden text-ellipsis">
             {displayName}
           </div>
-          <div
-            style={{
-              fontSize: 10,
-              color: 'var(--fg-muted)',
-              fontFamily: 'var(--font-mono)',
-            }}
-          >
+          <div className="text-[10px] text-fg-muted font-mono">
             {user?.email ? 'signed in' : 'local · on-prem'}
           </div>
         </span>
         <span
-          style={{
-            color: 'var(--fg-muted)',
-            transform: open ? 'rotate(180deg)' : undefined,
-            transition: 'transform var(--dur-fast)',
-          }}
+          className={cn(
+            'text-fg-muted transition-transform duration-[var(--dur-fast)]',
+            open && 'rotate-180',
+          )}
         >
           {I.ChevronDown(14)}
         </span>
@@ -265,26 +189,12 @@ function MenuRow({
       role="menuitem"
       onClick={onClick}
       disabled={disabled}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        width: '100%',
-        padding: '7px 10px',
-        border: 'none',
-        background: 'transparent',
-        fontSize: 13,
-        fontFamily: 'var(--font-sans)',
-        color: disabled
-          ? 'var(--fg-muted)'
-          : danger
-            ? 'var(--destructive)'
-            : 'var(--fg)',
-        opacity: disabled ? 0.5 : 1,
-        borderRadius: 'var(--radius-sm)',
-        textAlign: 'left',
-        cursor: disabled ? 'not-allowed' : 'pointer',
-      }}
+      className={cn(
+        'flex items-center gap-2.5 w-full px-2.5 py-[7px] border-none bg-transparent text-[13px] font-sans rounded-sm text-left',
+        disabled
+          ? 'text-fg-muted opacity-50 cursor-not-allowed'
+          : cn(danger ? 'text-destructive' : 'text-fg', 'opacity-100 cursor-pointer'),
+      )}
       onMouseEnter={(e) => {
         if (disabled) return
         e.currentTarget.style.background = danger
@@ -296,15 +206,14 @@ function MenuRow({
       }}
     >
       <span
-        style={{
-          display: 'inline-flex',
-          flexShrink: 0,
-          color: danger ? 'var(--destructive)' : 'var(--fg-muted)',
-        }}
+        className={cn(
+          'inline-flex shrink-0',
+          danger ? 'text-destructive' : 'text-fg-muted',
+        )}
       >
         {icon}
       </span>
-      <span style={{ flex: 1, minWidth: 0 }}>{label}</span>
+      <span className="flex-1 min-w-0">{label}</span>
     </button>
   )
 }

--- a/ui/src/components/record/LiveLevelMeter.tsx
+++ b/ui/src/components/record/LiveLevelMeter.tsx
@@ -90,13 +90,8 @@ export function LiveLevelMeter({ stream, active, height = 80 }: Props) {
   return (
     <canvas
       ref={canvasRef}
-      style={{
-        width: '100%',
-        height,
-        display: 'block',
-        background: 'var(--muted)',
-        borderRadius: 'var(--radius-md)',
-      }}
+      className="w-full block bg-muted rounded-md"
+      style={{ height }}
     />
   )
 }

--- a/ui/src/components/rooms/DailyRoom.tsx
+++ b/ui/src/components/rooms/DailyRoom.tsx
@@ -158,11 +158,7 @@ export function DailyRoom({ roomName, meeting, room: _room }: Props) {
   return (
     <div
       ref={setContainer}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--gh-off-black)',
-      }}
+      className="fixed inset-0 bg-[var(--gh-off-black)]"
     />
   )
 }

--- a/ui/src/components/rooms/DeleteRoomDialog.tsx
+++ b/ui/src/components/rooms/DeleteRoomDialog.tsx
@@ -22,49 +22,21 @@ export function DeleteRoomDialog({ name, onClose, onConfirm, loading }: Props) {
     <>
       <div className="rf-modal-backdrop" onClick={onClose} />
       <div
-        className="rf-modal"
+        className="rf-modal w-[min(440px,calc(100vw-32px))]"
         role="dialog"
         aria-modal="true"
-        style={{ width: 'min(440px, calc(100vw - 32px))' }}
       >
-        <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-            <div
-              style={{
-                flexShrink: 0,
-                width: 36,
-                height: 36,
-                borderRadius: 10,
-                background: 'color-mix(in srgb, var(--destructive) 12%, transparent)',
-                color: 'var(--destructive)',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
+        <div className="p-6 flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 w-9 h-9 rounded-[10px] bg-[color-mix(in_srgb,var(--destructive)_12%,transparent)] text-destructive inline-flex items-center justify-center">
               {I.Trash(18)}
             </div>
-            <div style={{ flex: 1 }}>
-              <h2
-                style={{
-                  margin: 0,
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 18,
-                  fontWeight: 600,
-                  color: 'var(--fg)',
-                }}
-              >
+            <div className="flex-1">
+              <h2 className="m-0 font-serif text-lg font-semibold text-fg">
                 Delete room?
               </h2>
-              <p
-                style={{
-                  margin: '6px 0 0',
-                  fontSize: 13,
-                  color: 'var(--fg-muted)',
-                  lineHeight: 1.5,
-                }}
-              >
-                <strong style={{ color: 'var(--fg)', fontFamily: 'var(--font-mono)' }}>
+              <p className="mt-1.5 mb-0 text-[13px] text-fg-muted leading-[1.5]">
+                <strong className="text-fg font-mono">
                   /{name}
                 </strong>{' '}
                 will be permanently removed. Existing recordings from this room are not affected.
@@ -73,20 +45,12 @@ export function DeleteRoomDialog({ name, onClose, onConfirm, loading }: Props) {
             </div>
           </div>
         </div>
-        <footer
-          style={{
-            padding: '14px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            gap: 10,
-            justifyContent: 'flex-end',
-          }}
-        >
+        <footer className="px-5 py-3.5 border-t border-border flex gap-2.5 justify-end">
           <Button
             variant="ghost"
             size="md"
             onClick={onClose}
-            style={{ color: 'var(--fg)', fontWeight: 600 }}
+            className="text-fg font-semibold"
           >
             Cancel
           </Button>
@@ -95,12 +59,7 @@ export function DeleteRoomDialog({ name, onClose, onConfirm, loading }: Props) {
             size="md"
             onClick={onConfirm}
             disabled={loading}
-            style={{
-              background: 'var(--destructive)',
-              color: 'var(--destructive-fg)',
-              borderColor: 'var(--destructive)',
-              boxShadow: 'var(--shadow-xs)',
-            }}
+            className="bg-destructive text-destructive-fg border-destructive shadow-xs"
           >
             {I.Trash(14)} {loading ? 'Deleting…' : 'Delete room'}
           </Button>

--- a/ui/src/components/rooms/GuestBanner.tsx
+++ b/ui/src/components/rooms/GuestBanner.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '@/auth/AuthContext'
+
+type Props = {
+  roomName: string
+}
+
+/**
+ * Slim top strip shown to unauthenticated visitors on a room page so
+ * calendar-invite guests have a clear "you're entering as a guest" cue
+ * and a path to sign in. Authenticated users see nothing.
+ */
+export function GuestBanner({ roomName }: Props) {
+  const { authenticated, loading } = useAuth()
+  if (loading || authenticated) return null
+  return (
+    <div
+      role="banner"
+      className="fixed top-0 left-0 right-0 z-[100] h-12 flex items-center justify-between px-[18px] bg-card border-b border-border shadow-xs font-sans"
+    >
+      <span className="text-sm text-fg-muted">
+        Joining{' '}
+        <span className="text-fg font-serif">{roomName}</span>{' '}
+        as a guest
+      </span>
+      <Link
+        to="/welcome"
+        state={{ from: `/${roomName}` }}
+        className="text-[13px] text-primary no-underline font-medium"
+      >
+        Sign in
+      </Link>
+    </div>
+  )
+}

--- a/ui/src/components/rooms/LiveKitRoom.tsx
+++ b/ui/src/components/rooms/LiveKitRoom.tsx
@@ -113,14 +113,7 @@ export function LiveKitRoom({ roomName, meeting, room: _room }: Props) {
     return (
       <div
         data-lk-theme="default"
-        style={{
-          position: 'fixed',
-          inset: 0,
-          background: 'var(--gh-off-black)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
+        className="fixed inset-0 bg-[var(--gh-off-black)] flex items-center justify-center"
       >
         <PreJoin
           defaults={{
@@ -151,11 +144,7 @@ export function LiveKitRoom({ roomName, meeting, room: _room }: Props) {
   return (
     <div
       data-lk-theme="default"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'black',
-      }}
+      className="fixed inset-0 bg-black"
     >
       <LKRoom
         serverUrl={serverUrl}

--- a/ui/src/components/rooms/MeetingSelection.tsx
+++ b/ui/src/components/rooms/MeetingSelection.tsx
@@ -44,50 +44,14 @@ export function MeetingSelection({
   }, [meetings])
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        background: 'var(--bg)',
-      }}
-    >
+    <div className="flex flex-col min-h-screen bg-bg">
       <MinimalHeader title={roomName} crumb={['room']} />
-      <main
-        style={{
-          flex: 1,
-          padding: 24,
-          maxWidth: 720,
-          width: '100%',
-          margin: '0 auto',
-          boxSizing: 'border-box',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 20,
-        }}
-      >
+      <main className="flex-1 p-6 max-w-[720px] w-full mx-auto box-border flex flex-col gap-5">
         <header>
-          <h1
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 24,
-              fontWeight: 600,
-              letterSpacing: '-0.02em',
-              color: 'var(--fg)',
-            }}
-          >
+          <h1 className="m-0 font-serif text-2xl font-semibold tracking-[-0.02em] text-fg">
             {roomName}
           </h1>
-          <p
-            style={{
-              margin: '6px 0 0',
-              fontSize: 13,
-              color: 'var(--fg-muted)',
-              fontFamily: 'var(--font-sans)',
-              lineHeight: 1.5,
-            }}
-          >
+          <p className="mt-1.5 mb-0 text-[13px] text-fg-muted font-sans leading-[1.5]">
             Join an active meeting or start an unscheduled one.
           </p>
         </header>
@@ -122,47 +86,17 @@ export function MeetingSelection({
         )}
 
         {!loading && current.length === 0 && upcoming.length === 0 && (
-          <p
-            style={{
-              margin: 0,
-              fontSize: 13,
-              color: 'var(--fg-muted)',
-              fontFamily: 'var(--font-sans)',
-              fontStyle: 'italic',
-            }}
-          >
+          <p className="m-0 text-[13px] text-fg-muted font-sans italic">
             No active or upcoming meetings on the calendar right now.
           </p>
         )}
 
-        <div
-          style={{
-            marginTop: 8,
-            paddingTop: 20,
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontSize: 13,
-                fontWeight: 500,
-                color: 'var(--fg)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+        <div className="mt-2 pt-5 border-t border-border flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-medium text-fg font-sans">
               Need a quick call?
             </div>
-            <div
-              style={{
-                fontSize: 12,
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+            <div className="text-xs text-fg-muted font-sans">
               Spin up an unscheduled meeting in this room.
             </div>
           </div>
@@ -188,20 +122,11 @@ function Section({
   children: React.ReactNode
 }) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <div
-        style={{
-          fontFamily: 'var(--font-sans)',
-          fontSize: 11,
-          fontWeight: 600,
-          letterSpacing: '0.04em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-muted)',
-        }}
-      >
+    <div className="flex flex-col gap-2">
+      <div className="font-sans text-[11px] font-semibold tracking-[0.04em] uppercase text-fg-muted">
         {label}
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div className="flex flex-col gap-2">
         {children}
       </div>
     </div>
@@ -221,49 +146,20 @@ function MeetingCard({
 }) {
   return (
     <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '12px 16px',
-        background: 'var(--card)',
-        border: '1px solid',
-        borderColor: accent ? 'var(--primary)' : 'var(--border)',
-        borderRadius: 'var(--radius-md)',
-        boxShadow: accent ? 'var(--shadow-xs)' : 'none',
-      }}
+      className={
+        accent
+          ? 'flex items-center gap-3 px-4 py-3 bg-card border border-primary rounded-md shadow-xs'
+          : 'flex items-center gap-3 px-4 py-3 bg-card border border-border rounded-md'
+      }
     >
       {accent && (
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 999,
-            background: 'var(--status-live)',
-            boxShadow:
-              '0 0 0 4px color-mix(in srgb, var(--status-live) 25%, transparent)',
-            flexShrink: 0,
-          }}
-        />
+        <span className="w-2 h-2 rounded-full bg-status-live shrink-0 shadow-[0_0_0_4px_color-mix(in_srgb,var(--status-live)_25%,transparent)]" />
       )}
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontFamily: 'var(--font-sans)',
-            fontSize: 13.5,
-            fontWeight: 500,
-            color: 'var(--fg)',
-          }}
-        >
+      <div className="flex-1 min-w-0">
+        <div className="font-sans text-[13.5px] font-medium text-fg">
           {fmtDate(meeting.start_date)}
         </div>
-        <div
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 11,
-            color: 'var(--fg-muted)',
-          }}
-        >
+        <div className="font-mono text-[11px] text-fg-muted">
           {new Date(meeting.start_date).toLocaleTimeString([], {
             hour: '2-digit',
             minute: '2-digit',
@@ -284,15 +180,7 @@ function MeetingCard({
 
 function MeetingListSkeleton() {
   return (
-    <div
-      style={{
-        color: 'var(--fg-muted)',
-        fontSize: 13,
-        fontFamily: 'var(--font-sans)',
-        textAlign: 'center',
-        padding: 32,
-      }}
-    >
+    <div className="text-fg-muted text-[13px] font-sans text-center p-8">
       Loading meetings…
     </div>
   )

--- a/ui/src/components/rooms/RoomFormDialog.tsx
+++ b/ui/src/components/rooms/RoomFormDialog.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { components } from '@/api/schema'
 import { apiClient } from '@/api/client'
 import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
 import { Combobox } from '@/components/ui/Combobox'
+import { cn } from '@/lib/utils'
 
 type Room = components['schemas']['RoomDetails']
 
@@ -147,59 +148,32 @@ export function RoomFormDialog({ room, onClose, onSave, saving }: Props) {
     }
   }
 
-  const panelStyle: CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 16,
-    padding: 20,
-    overflow: 'auto',
-    flex: 1,
-    maxHeight: 'calc(100vh - 260px)',
-  }
-
   return (
     <>
       <div className="rf-modal-backdrop" onClick={() => !saving && onClose()} />
       <div
-        className="rf-modal"
+        className="rf-modal w-[min(600px,calc(100vw-32px))]"
         role="dialog"
         aria-modal="true"
         aria-labelledby="rf-room-title"
-        style={{ width: 'min(600px, calc(100vw - 32px))' }}
       >
         <form
           onSubmit={(e) => {
             e.preventDefault()
             void submit()
           }}
-          style={{ display: 'flex', flexDirection: 'column' }}
+          className="flex flex-col"
         >
-          <header
-            style={{ padding: '18px 20px 0', display: 'flex', alignItems: 'flex-start' }}
-          >
-            <div style={{ flex: 1 }}>
+          <header className="pt-[18px] px-5 flex items-start">
+            <div className="flex-1">
               <h2
                 id="rf-room-title"
-                style={{
-                  margin: 0,
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 20,
-                  fontWeight: 600,
-                  letterSpacing: '-0.01em',
-                  color: 'var(--fg)',
-                }}
+                className="m-0 font-serif text-xl font-semibold tracking-[-0.01em] text-fg"
               >
                 {isEdit ? 'Edit room' : 'New room'}
               </h2>
               {isEdit && (
-                <p
-                  style={{
-                    margin: '2px 0 0',
-                    fontSize: 12,
-                    color: 'var(--fg-muted)',
-                    fontFamily: 'var(--font-mono)',
-                  }}
-                >
+                <p className="mt-0.5 mb-0 text-xs text-fg-muted font-mono">
                   /{room!.name}
                 </p>
               )}
@@ -208,47 +182,24 @@ export function RoomFormDialog({ room, onClose, onSave, saving }: Props) {
               type="button"
               onClick={onClose}
               aria-label="Close"
-              style={{
-                border: 'none',
-                background: 'transparent',
-                padding: 6,
-                cursor: 'pointer',
-                color: 'var(--fg-muted)',
-                borderRadius: 'var(--radius-sm)',
-                display: 'inline-flex',
-              }}
+              className="border-none bg-transparent p-1.5 cursor-pointer text-fg-muted rounded-sm inline-flex"
             >
               {I.X(16)}
             </button>
           </header>
 
-          <div
-            style={{
-              display: 'flex',
-              gap: 0,
-              padding: '14px 20px 0',
-              borderBottom: '1px solid var(--border)',
-            }}
-          >
+          <div className="flex gap-0 pt-3.5 px-5 border-b border-border">
             {visibleTabs.map((t) => (
               <button
                 key={t.id}
                 type="button"
                 onClick={() => setTab(t.id)}
-                style={{
-                  position: 'relative',
-                  padding: '8px 14px 10px',
-                  border: 'none',
-                  background: 'transparent',
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: 13,
-                  fontWeight: 500,
-                  color: tab === t.id ? 'var(--fg)' : 'var(--fg-muted)',
-                  cursor: 'pointer',
-                  marginBottom: -1,
-                  borderBottom: '2px solid',
-                  borderBottomColor: tab === t.id ? 'var(--primary)' : 'transparent',
-                }}
+                className={cn(
+                  'relative px-3.5 pt-2 pb-2.5 border-none bg-transparent font-sans text-[13px] font-medium cursor-pointer -mb-px border-b-2',
+                  tab === t.id
+                    ? 'text-fg border-primary'
+                    : 'text-fg-muted border-transparent',
+                )}
               >
                 {t.label}
               </button>
@@ -258,21 +209,13 @@ export function RoomFormDialog({ room, onClose, onSave, saving }: Props) {
           {formError && (
             <div
               role="alert"
-              style={{
-                margin: '12px 20px 0',
-                fontSize: 13,
-                color: 'var(--destructive)',
-                background: 'color-mix(in srgb, var(--destructive) 8%, transparent)',
-                border: '1px solid color-mix(in srgb, var(--destructive) 25%, transparent)',
-                borderRadius: 'var(--radius-md)',
-                padding: '8px 12px',
-              }}
+              className="mt-3 mx-5 text-[13px] text-destructive bg-[color-mix(in_srgb,var(--destructive)_8%,transparent)] border border-[color-mix(in_srgb,var(--destructive)_25%,transparent)] rounded-md px-3 py-2"
             >
               {formError}
             </div>
           )}
 
-          <div style={panelStyle}>
+          <div className="flex flex-col gap-4 p-5 overflow-auto flex-1 max-h-[calc(100vh-260px)]">
             {tab === 'general' && (
               <GeneralTab
                 name={name}
@@ -331,23 +274,15 @@ export function RoomFormDialog({ room, onClose, onSave, saving }: Props) {
             )}
           </div>
 
-          <footer
-            style={{
-              padding: '14px 20px',
-              borderTop: '1px solid var(--border)',
-              display: 'flex',
-              gap: 10,
-              alignItems: 'center',
-            }}
-          >
-            <div style={{ flex: 1 }} />
+          <footer className="px-5 py-3.5 border-t border-border flex gap-2.5 items-center">
+            <div className="flex-1" />
             <Button
               type="button"
               variant="ghost"
               size="md"
               onClick={onClose}
               disabled={saving}
-              style={{ color: 'var(--fg)', fontWeight: 600 }}
+              className="text-fg font-semibold"
             >
               Cancel
             </Button>
@@ -356,7 +291,7 @@ export function RoomFormDialog({ room, onClose, onSave, saving }: Props) {
               variant="primary"
               size="md"
               disabled={!canSave}
-              style={!canSave ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
+              className={!canSave ? 'opacity-50 cursor-not-allowed' : undefined}
             >
               {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Add room'}
             </Button>
@@ -382,18 +317,15 @@ function FormField({
 }) {
   return (
     <div>
-      <label className="rf-label" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <label className="rf-label flex items-center gap-1.5">
         {label}
         {info && (
-          <span
-            title={info}
-            style={{ display: 'inline-flex', color: 'var(--fg-muted)', cursor: 'help' }}
-          >
+          <span title={info} className="inline-flex text-fg-muted cursor-help">
             {I.Info(12)}
           </span>
         )}
       </label>
-      <div style={{ marginTop: 6 }}>{children}</div>
+      <div className="mt-1.5">{children}</div>
       {hint && <div className="rf-hint">{hint}</div>}
     </div>
   )
@@ -411,54 +343,27 @@ function Checkbox({
   hint?: ReactNode
 }) {
   return (
-    <label
-      style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 10,
-        cursor: 'pointer',
-        fontFamily: 'var(--font-sans)',
-        padding: '6px 0',
-      }}
-    >
+    <label className="flex items-start gap-2.5 cursor-pointer font-sans py-1.5">
       <span
-        style={{
-          flexShrink: 0,
-          marginTop: 1,
-          width: 16,
-          height: 16,
-          borderRadius: 4,
-          border: '1.5px solid',
-          borderColor: checked ? 'var(--primary)' : 'var(--gh-grey-4)',
-          background: checked ? 'var(--primary)' : 'var(--card)',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'var(--primary-fg)',
-          transition: 'all var(--dur-fast)',
-          position: 'relative',
-        }}
+        className={cn(
+          'shrink-0 mt-px w-4 h-4 rounded-[4px] border-[1.5px] inline-flex items-center justify-center text-primary-fg transition-all duration-[var(--dur-fast)] relative',
+          checked
+            ? 'border-primary bg-primary'
+            : 'border-[var(--gh-grey-4)] bg-card',
+        )}
       >
         <input
           type="checkbox"
           checked={checked}
           onChange={(e) => onChange(e.target.checked)}
-          style={{ position: 'absolute', opacity: 0, width: 0, height: 0 }}
+          className="absolute opacity-0 w-0 h-0"
         />
         {checked && I.Check(11)}
       </span>
-      <span style={{ flex: 1, minWidth: 0 }}>
-        <span style={{ fontSize: 13, color: 'var(--fg)', fontWeight: 500 }}>{label}</span>
+      <span className="flex-1 min-w-0">
+        <span className="text-[13px] text-fg font-medium">{label}</span>
         {hint && (
-          <span
-            style={{
-              display: 'block',
-              marginTop: 2,
-              fontSize: 11.5,
-              color: 'var(--fg-muted)',
-              lineHeight: 1.4,
-            }}
-          >
+          <span className="block mt-0.5 text-[11.5px] text-fg-muted leading-[1.4]">
             {hint}
           </span>
         )}
@@ -469,21 +374,8 @@ function Checkbox({
 
 function InfoBanner({ children }: { children: ReactNode }) {
   return (
-    <div
-      style={{
-        padding: '12px 14px',
-        fontSize: 12,
-        lineHeight: 1.5,
-        color: 'var(--fg-muted)',
-        background: 'var(--muted)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-md)',
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 10,
-      }}
-    >
-      <span style={{ color: 'var(--primary)', marginTop: 1, flexShrink: 0 }}>
+    <div className="px-3.5 py-3 text-xs leading-[1.5] text-fg-muted bg-muted border border-border rounded-md flex items-start gap-2.5">
+      <span className="text-primary mt-px shrink-0">
         {I.Info(14)}
       </span>
       <div>{children}</div>
@@ -528,17 +420,16 @@ function GeneralTab(p: GeneralTabProps) {
         hint={p.nameError || (!p.isEdit ? 'No spaces or special characters allowed' : undefined)}
       >
         <input
-          className="rf-input"
+          className={cn('rf-input', p.nameError && 'border-destructive')}
           type="text"
           autoFocus={!p.isEdit}
           disabled={p.isEdit}
           placeholder="room-name"
           value={p.name}
           onChange={(e) => p.setName(e.target.value)}
-          style={p.nameError ? { borderColor: 'var(--destructive)' } : undefined}
         />
         {p.isEdit && (
-          <div className="rf-hint" style={{ color: 'var(--fg-muted)' }}>
+          <div className="rf-hint text-fg-muted">
             Room name can't be changed after creation.
           </div>
         )}
@@ -799,9 +690,9 @@ function WebhookTab(p: WebhookTabProps) {
     <>
       <InfoBanner>
         Reflector POSTs a JSON payload to your URL on lifecycle events:{' '}
-        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>meeting.started</code>,{' '}
-        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>meeting.ended</code>,{' '}
-        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>transcript.ready</code>.
+        <code className="font-mono text-[11px]">meeting.started</code>,{' '}
+        <code className="font-mono text-[11px]">meeting.ended</code>,{' '}
+        <code className="font-mono text-[11px]">transcript.ready</code>.
       </InfoBanner>
 
       <FormField

--- a/ui/src/components/rooms/RoomsTable.tsx
+++ b/ui/src/components/rooms/RoomsTable.tsx
@@ -52,21 +52,11 @@ function recordingLabel(type: string, trigger: string | null | undefined) {
 
 function CalendarSyncIcon({ size = 14 }: { size?: number }) {
   return (
-    <span style={{ position: 'relative', display: 'inline-flex', width: size, height: size }}>
+    <span className="relative inline-flex" style={{ width: size, height: size }}>
       {I.Calendar(size)}
       <span
-        style={{
-          position: 'absolute',
-          right: -3,
-          bottom: -3,
-          width: size * 0.65,
-          height: size * 0.65,
-          background: 'var(--card)',
-          borderRadius: 9999,
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
+        className="absolute -right-[3px] -bottom-[3px] bg-card rounded-full inline-flex items-center justify-center"
+        style={{ width: size * 0.65, height: size * 0.65 }}
       >
         {I.Refresh(size * 0.55)}
       </span>
@@ -103,48 +93,21 @@ type RoomRowProps = {
 function RoomRow({ room, onEdit, onDelete, onCopy, copied }: RoomRowProps) {
   const recording = recordingLabel(room.recording_type, room.recording_trigger)
   return (
-    <div
-      className="rf-row"
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
-        alignItems: 'center',
-        columnGap: 18,
-        padding: '14px 20px',
-        borderBottom: '1px solid var(--border)',
-        cursor: 'pointer',
-        position: 'relative',
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
+    <div className="rf-row grid grid-cols-[auto_1fr_auto] items-center gap-x-[18px] px-5 py-3.5 border-b border-border cursor-pointer relative">
+      <div className="flex items-center gap-2.5 shrink-0">
         <StatusDot status="idle" size={7} />
       </div>
 
-      <div style={{ minWidth: 0, display: 'flex', flexDirection: 'column', gap: 5 }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            minWidth: 0,
-            flexWrap: 'wrap',
-            rowGap: 4,
-          }}
-        >
+      <div className="min-w-0 flex flex-col gap-[5px]">
+        <div className="flex items-center gap-2.5 min-w-0 flex-wrap gap-y-1">
           <a
             href={roomUrl(room)}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 14.5,
-              fontWeight: 600,
-              color: 'var(--fg)',
-              textDecoration: 'none',
-            }}
+            className="font-mono text-[14.5px] font-semibold text-fg no-underline"
           >
-            <span style={{ color: 'var(--fg-muted)', fontWeight: 500 }}>/</span>
+            <span className="text-fg-muted font-medium">/</span>
             <span>{room.name}</span>
           </a>
           {room.ics_enabled && (
@@ -154,40 +117,24 @@ function RoomRow({ room, onEdit, onDelete, onCopy, copied }: RoomRowProps) {
           )}
         </div>
 
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            rowGap: 3,
-            columnGap: 0,
-            fontSize: 11.5,
-            color: 'var(--fg-muted)',
-            fontFamily: 'var(--font-sans)',
-          }}
-        >
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+        <div className="flex items-center flex-wrap gap-y-[3px] gap-x-0 text-[11.5px] text-fg-muted font-sans">
+          <span className="inline-flex items-center gap-[5px]">
             <span
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: 2,
-                display: 'inline-block',
-                background: PLATFORM_COLOR[room.platform],
-              }}
+              className="w-2 h-2 rounded-[2px] inline-block"
+              style={{ background: PLATFORM_COLOR[room.platform] }}
             />
             {platformLabel(room.platform)}
           </span>
 
           <Dot />
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+          <span className="inline-flex items-center gap-[5px]">
             {I.Users(11)} {roomModeLabel(room.room_mode)}
           </span>
 
           {recording && (
             <>
               <Dot />
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <span className="inline-flex items-center gap-[5px]">
                 {room.recording_type === 'cloud' ? I.Cloud(11) : I.Download(11)}
                 {recording}
               </span>
@@ -197,36 +144,15 @@ function RoomRow({ room, onEdit, onDelete, onCopy, copied }: RoomRowProps) {
           {room.zulip_auto_post && room.zulip_stream && (
             <>
               <Dot />
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 5,
-                  minWidth: 0,
-                }}
-              >
-                <span
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    width: 12,
-                    height: 12,
-                    fontSize: 9,
-                    fontWeight: 700,
-                    background: 'var(--gh-grey-5)',
-                    color: 'var(--gh-off-white)',
-                    borderRadius: 2,
-                    fontFamily: 'var(--font-sans)',
-                  }}
-                >
+              <span className="inline-flex items-center gap-[5px] min-w-0">
+                <span className="inline-flex items-center justify-center w-3 h-3 text-[9px] font-bold bg-[var(--gh-grey-5)] text-[var(--gh-off-white)] rounded-[2px] font-sans">
                   Z
                 </span>
-                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
+                <span className="font-mono text-[11px]">
                   {room.zulip_stream}
                   {room.zulip_topic && (
                     <>
-                      <span style={{ color: 'var(--gh-grey-3)', margin: '0 4px' }}>›</span>
+                      <span className="text-[var(--gh-grey-3)] mx-1">›</span>
                       {room.zulip_topic}
                     </>
                   )}
@@ -237,21 +163,13 @@ function RoomRow({ room, onEdit, onDelete, onCopy, copied }: RoomRowProps) {
         </div>
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <div className="flex items-center gap-0.5">
         {copied && (
-          <span
-            style={{
-              color: 'var(--status-ok)',
-              fontSize: 11.5,
-              fontFamily: 'var(--font-mono)',
-              fontWeight: 600,
-              paddingRight: 6,
-            }}
-          >
+          <span className="text-status-ok text-[11.5px] font-mono font-semibold pr-1.5">
             Copied
           </span>
         )}
-        <div style={{ display: 'flex', gap: 2 }}>
+        <div className="flex gap-0.5">
           {room.ics_enabled && (
             <Button
               variant="ghost"
@@ -320,20 +238,7 @@ function Pill({
   return (
     <span
       title={title}
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 4,
-        padding: '1px 7px',
-        height: 18,
-        fontFamily: 'var(--font-sans)',
-        fontSize: 10.5,
-        fontWeight: 500,
-        color: 'var(--fg-muted)',
-        background: 'var(--muted)',
-        border: '1px solid var(--border)',
-        borderRadius: 9999,
-      }}
+      className="inline-flex items-center gap-1 px-[7px] py-px h-[18px] font-sans text-[10.5px] font-medium text-fg-muted bg-muted border border-border rounded-full"
     >
       {icon}
       {children}
@@ -342,5 +247,5 @@ function Pill({
 }
 
 function Dot() {
-  return <span style={{ margin: '0 10px', color: 'var(--gh-grey-3)' }}>·</span>
+  return <span className="mx-2.5 text-[var(--gh-grey-3)]">·</span>
 }

--- a/ui/src/components/rooms/WherebyRoom.tsx
+++ b/ui/src/components/rooms/WherebyRoom.tsx
@@ -97,13 +97,7 @@ export function WherebyRoom({ roomName, meeting, room: _room }: Props) {
 
   const url = joined.host_room_url || joined.room_url
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--gh-off-black)',
-      }}
-    >
+    <div className="fixed inset-0 bg-[var(--gh-off-black)]">
       <whereby-embed
         ref={embedRef}
         room={url}

--- a/ui/src/components/rooms/roomChrome.tsx
+++ b/ui/src/components/rooms/roomChrome.tsx
@@ -2,19 +2,7 @@ import { Button } from '@/components/ui/primitives'
 
 export function RoomLoading({ label }: { label: string }) {
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--bg)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: 'var(--fg-muted)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 14,
-      }}
-    >
+    <div className="fixed inset-0 bg-bg flex items-center justify-center text-fg-muted font-sans text-sm">
       {label}
     </div>
   )
@@ -28,28 +16,8 @@ export function RoomError({
   onLeave: () => void
 }) {
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--bg)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'column',
-        gap: 14,
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
-      <p
-        style={{
-          margin: 0,
-          color: 'var(--destructive)',
-          fontSize: 15,
-          maxWidth: 380,
-          textAlign: 'center',
-        }}
-      >
+    <div className="fixed inset-0 bg-bg flex items-center justify-center flex-col gap-3.5 font-sans">
+      <p className="m-0 text-destructive text-[15px] max-w-[380px] text-center">
         {message}
       </p>
       <Button variant="outline" size="sm" onClick={onLeave}>

--- a/ui/src/components/shared/NewTranscriptDialog.tsx
+++ b/ui/src/components/shared/NewTranscriptDialog.tsx
@@ -13,7 +13,7 @@ type Props = {
 export function NewTranscriptDialog({ onClose }: Props) {
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
-  const [sourceLang, setSourceLang] = useState('en')
+  const [sourceLang, setSourceLang] = useState('auto')
   const [targetLang, setTargetLang] = useState('')
   const [submitting, setSubmitting] = useState(false)
 
@@ -28,15 +28,17 @@ export function NewTranscriptDialog({ onClose }: Props) {
   const createAndGo = async (kind: 'live' | 'file') => {
     setSubmitting(true)
     try {
-      // Backend's CreateTranscript requires real strings for name + both
-      // language fields. Fall back to sensible defaults instead of sending
-      // null, which triggers a 422. Target defaults to source — meaning no
-      // effective translation — when the user doesn't pick one.
+      // Backend accepts source_language: str | None — null is the
+      // auto-detect signal. Target falls back to source (or "en" when
+      // source is auto) so the translator has a concrete target.
+      const sourcePayload = sourceLang === 'auto' ? null : sourceLang
+      const targetPayload =
+        targetLang || (sourceLang === 'auto' ? 'en' : sourceLang)
       const { data, response } = await apiClient.POST('/v1/transcripts', {
         body: {
           name: title.trim() || 'Untitled',
-          source_language: sourceLang,
-          target_language: targetLang || sourceLang,
+          source_language: sourcePayload,
+          target_language: targetPayload,
           source_kind: kind,
         } as never,
       })
@@ -60,78 +62,40 @@ export function NewTranscriptDialog({ onClose }: Props) {
         aria-modal="true"
         aria-labelledby="rf-new-title"
       >
-        <header
-          style={{
-            padding: '18px 20px 14px',
-            display: 'flex',
-            alignItems: 'center',
-            borderBottom: '1px solid var(--border)',
-          }}
-        >
-          <div style={{ flex: 1 }}>
+        <header className="pt-[18px] px-5 pb-3.5 flex items-center border-b border-border">
+          <div className="flex-1">
             <h2
               id="rf-new-title"
-              style={{
-                margin: 0,
-                fontFamily: 'var(--font-serif)',
-                fontSize: 20,
-                fontWeight: 600,
-                letterSpacing: '-0.01em',
-                color: 'var(--fg)',
-              }}
+              className="m-0 font-serif text-xl font-semibold tracking-[-0.01em] text-fg"
             >
               New transcript
             </h2>
-            <p
-              style={{
-                margin: '2px 0 0',
-                fontSize: 12.5,
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+            <p className="mt-0.5 mb-0 mx-0 text-[12.5px] text-fg-muted font-sans">
               Record live or upload a file. You can edit details later.
             </p>
           </div>
           <button
             onClick={onClose}
             aria-label="Close"
-            style={{
-              border: 'none',
-              background: 'transparent',
-              padding: 6,
-              cursor: 'pointer',
-              color: 'var(--fg-muted)',
-              borderRadius: 'var(--radius-sm)',
-              display: 'inline-flex',
-            }}
+            className="border-none bg-transparent p-1.5 cursor-pointer text-fg-muted rounded-sm inline-flex"
           >
             {I.X(16)}
           </button>
         </header>
 
-        <div
-          style={{
-            padding: 20,
-            overflow: 'auto',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 16,
-          }}
-        >
+        <div className="p-5 overflow-auto flex flex-col gap-4">
           <div>
             <label className="rf-label" htmlFor="rf-nd-title">
               Title
             </label>
             <input
               id="rf-nd-title"
-              className="rf-input"
+              className="rf-input mt-1.5"
               type="text"
               autoFocus
               placeholder="e.g. Sprint review — June 12"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              style={{ marginTop: 6 }}
             />
           </div>
 
@@ -141,10 +105,9 @@ export function NewTranscriptDialog({ onClose }: Props) {
             </label>
             <select
               id="rf-nd-source"
-              className="rf-select"
+              className="rf-select mt-1.5"
               value={sourceLang}
               onChange={(e) => setSourceLang(e.target.value)}
-              style={{ marginTop: 6 }}
             >
               {REFLECTOR_LANGS.map((l) => (
                 <option key={l.code} value={l.code}>
@@ -161,13 +124,12 @@ export function NewTranscriptDialog({ onClose }: Props) {
             </label>
             <select
               id="rf-nd-target"
-              className="rf-select"
+              className="rf-select mt-1.5"
               value={targetLang}
               onChange={(e) => setTargetLang(e.target.value)}
-              style={{ marginTop: 6 }}
             >
               <option value="">— None (same as spoken) —</option>
-              {REFLECTOR_LANGS.map((l) => (
+              {REFLECTOR_LANGS.filter((l) => l.code !== 'auto').map((l) => (
                 <option key={l.code} value={l.code}>
                   {l.flag} {l.name}
                 </option>
@@ -178,26 +140,8 @@ export function NewTranscriptDialog({ onClose }: Props) {
 
         </div>
 
-        <footer
-          style={{
-            padding: '14px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            gap: 10,
-            alignItems: 'center',
-          }}
-        >
-          <div
-            style={{
-              flex: 1,
-              fontSize: 11.5,
-              color: 'var(--fg-muted)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              fontFamily: 'var(--font-sans)',
-            }}
-          >
+        <footer className="py-3.5 px-5 border-t border-border flex gap-2.5 items-center">
+          <div className="flex-1 text-[11.5px] text-fg-muted flex items-center gap-1.5 font-sans">
             {I.Lock(12)}
             Audio stays on your infrastructure.
           </div>

--- a/ui/src/components/transcript/AudioPlayer.tsx
+++ b/ui/src/components/transcript/AudioPlayer.tsx
@@ -105,18 +105,7 @@ export function AudioPlayer({
   }
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 14,
-        padding: 14,
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        boxShadow: 'var(--shadow-xs)',
-      }}
-    >
+    <div className="flex items-center gap-3.5 p-3.5 bg-card border border-border rounded-lg shadow-xs">
       <Button
         variant="primary"
         size="icon"
@@ -130,44 +119,20 @@ export function AudioPlayer({
         title={playing ? 'Pause (Space)' : 'Play (Space)'}
       >
         {playing ? (
-          <span
-            style={{
-              display: 'inline-flex',
-              gap: 3,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <span style={{ width: 3, height: 12, background: 'currentColor' }} />
-            <span style={{ width: 3, height: 12, background: 'currentColor' }} />
+          <span className="inline-flex gap-[3px] items-center justify-center">
+            <span className="w-[3px] h-3 bg-current" />
+            <span className="w-[3px] h-3 bg-current" />
           </span>
         ) : (
-          <span
-            style={{
-              width: 0,
-              height: 0,
-              borderLeft: '10px solid currentColor',
-              borderTop: '7px solid transparent',
-              borderBottom: '7px solid transparent',
-              marginLeft: 2,
-            }}
-          />
+          <span className="w-0 h-0 border-l-[10px] border-l-current border-t-[7px] border-t-transparent border-b-[7px] border-b-transparent ml-0.5" />
         )}
       </Button>
 
-      <div style={{ flex: 1, minWidth: 0 }}>
+      <div className="flex-1 min-w-0">
         {loading ? (
-          <div style={{ color: 'var(--fg-muted)', fontSize: 12 }}>Loading audio…</div>
+          <div className="text-fg-muted text-xs">Loading audio…</div>
         ) : error ? (
-          <div
-            style={{
-              color: 'var(--destructive)',
-              fontSize: 12,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-            }}
-          >
+          <div className="text-destructive text-xs flex items-center gap-1.5">
             {I.AlertTriangle(12)} {error}
           </div>
         ) : (
@@ -181,15 +146,7 @@ export function AudioPlayer({
         )}
       </div>
 
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 12,
-          color: 'var(--fg-muted)',
-          minWidth: 88,
-          textAlign: 'right',
-        }}
-      >
+      <span className="font-mono text-xs text-fg-muted min-w-[88px] text-right">
         {fmtDur(Math.floor(currentTime))} / {fmtDur(Math.floor(duration))}
       </span>
 
@@ -198,7 +155,7 @@ export function AudioPlayer({
           ref={audioRef}
           src={blobUrl}
           preload="metadata"
-          style={{ display: 'none' }}
+          className="hidden"
           onLoadedMetadata={(e) => {
             const d = e.currentTarget.duration
             setDuration(d)

--- a/ui/src/components/transcript/Banners.tsx
+++ b/ui/src/components/transcript/Banners.tsx
@@ -3,22 +3,8 @@ import { I } from '@/components/icons'
 export function ErrorBanner({ message }: { message: string | null | undefined }) {
   const text = message?.trim() || 'Processing failed — reason unavailable.'
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 10,
-        padding: '10px 14px',
-        color: 'var(--destructive)',
-        background: 'color-mix(in oklch, var(--destructive) 8%, transparent)',
-        border: '1px solid color-mix(in oklch, var(--destructive) 22%, transparent)',
-        borderRadius: 'var(--radius-md)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 13,
-        lineHeight: 1.45,
-      }}
-    >
-      <span style={{ marginTop: 2, flexShrink: 0 }}>{I.AlertTriangle(14)}</span>
+    <div className="flex items-start gap-2.5 px-3.5 py-2.5 text-destructive bg-[color-mix(in_oklch,var(--destructive)_8%,transparent)] border border-[color-mix(in_oklch,var(--destructive)_22%,transparent)] rounded-md font-sans text-[13px] leading-[1.45]">
+      <span className="mt-0.5 shrink-0">{I.AlertTriangle(14)}</span>
       <span>{text}</span>
     </div>
   )
@@ -26,22 +12,8 @@ export function ErrorBanner({ message }: { message: string | null | undefined })
 
 export function AudioDeletedBanner() {
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 10,
-        padding: '10px 14px',
-        color: 'var(--fg-muted)',
-        background: 'var(--muted)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-md)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 13,
-        lineHeight: 1.45,
-      }}
-    >
-      <span style={{ marginTop: 2, flexShrink: 0 }}>{I.Lock(14)}</span>
+    <div className="flex items-start gap-2.5 px-3.5 py-2.5 text-fg-muted bg-muted border border-border rounded-md font-sans text-[13px] leading-[1.45]">
+      <span className="mt-0.5 shrink-0">{I.Lock(14)}</span>
       <span>
         No audio is available because one or more participants didn't consent to keep the
         audio.

--- a/ui/src/components/transcript/MetadataStrip.tsx
+++ b/ui/src/components/transcript/MetadataStrip.tsx
@@ -1,5 +1,6 @@
 import type { components } from '@/api/schema'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { fmtDate, fmtDur } from '@/lib/format'
 
 type Transcript = components['schemas']['GetTranscriptWithParticipants']
@@ -22,7 +23,7 @@ function toSeconds(value: number | null | undefined) {
 }
 
 function Dot() {
-  return <span style={{ margin: '0 8px', color: 'var(--gh-grey-3)' }}>·</span>
+  return <span className="mx-2 text-[var(--gh-grey-3)]">·</span>
 }
 
 export function MetadataStrip({ transcript, speakerCount }: Props) {
@@ -31,32 +32,18 @@ export function MetadataStrip({ transcript, speakerCount }: Props) {
   const shortId = transcript.id.slice(0, 8)
   const duration = toSeconds(transcript.duration)
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-        rowGap: 2,
-        fontSize: 11.5,
-        color: 'var(--fg-muted)',
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
-      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>#{shortId}</span>
+    <div className="flex items-center flex-wrap gap-y-0.5 text-[11.5px] text-fg-muted font-sans">
+      <span className="font-mono text-[11px]">#{shortId}</span>
       <Dot />
       <span>{sourceLabel(transcript)}</span>
       <Dot />
-      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
-        {fmtDate(transcript.created_at)}
-      </span>
+      <span className="font-mono text-[11px]">{fmtDate(transcript.created_at)}</span>
       <Dot />
-      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>
-        {fmtDur(duration)}
-      </span>
+      <span className="font-mono text-[11px]">{fmtDur(duration)}</span>
       {speakerCount > 0 && (
         <>
           <Dot />
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <span className="inline-flex items-center gap-1">
             {I.Users(11)} {speakerCount} {speakerCount === 1 ? 'speaker' : 'speakers'}
           </span>
         </>
@@ -65,21 +52,13 @@ export function MetadataStrip({ transcript, speakerCount }: Props) {
         <>
           <Dot />
           <span
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 4,
-              color: tgt && tgt !== src ? 'var(--primary)' : 'var(--fg-muted)',
-            }}
+            className={cn(
+              'inline-flex items-center gap-1',
+              tgt && tgt !== src ? 'text-primary' : 'text-fg-muted',
+            )}
           >
             {I.Globe(11)}
-            <span
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 10.5,
-                textTransform: 'uppercase',
-              }}
-            >
+            <span className="font-mono text-[10.5px] uppercase">
               {src}
               {tgt && tgt !== src && <> → {tgt}</>}
             </span>
@@ -89,7 +68,7 @@ export function MetadataStrip({ transcript, speakerCount }: Props) {
       {transcript.room_name && (
         <>
           <Dot />
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <span className="inline-flex items-center gap-1">
             {I.Door(11)} {transcript.room_name}
           </span>
         </>

--- a/ui/src/components/transcript/ShareDialog.tsx
+++ b/ui/src/components/transcript/ShareDialog.tsx
@@ -10,6 +10,7 @@ import { apiClient } from '@/api/client'
 import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
 import { Combobox } from '@/components/ui/Combobox'
+import { cn } from '@/lib/utils'
 import type { components } from '@/api/schema'
 
 type Transcript = components['schemas']['GetTranscriptWithParticipants']
@@ -37,8 +38,15 @@ const MODE_HINT: Record<ShareMode, string> = {
 }
 
 export function ShareDialog(props: Props) {
+  const mode = props.transcript.share_mode ?? 'private'
+  const fallbackUrl =
+    typeof window !== 'undefined'
+      ? mode === 'public'
+        ? `${window.location.origin}/v2/shared/${props.transcript.id}`
+        : `${window.location.origin}${window.location.pathname}`
+      : ''
   return (
-    <DialogBoundary onClose={props.onClose}>
+    <DialogBoundary onClose={props.onClose} fallbackUrl={fallbackUrl}>
       <ShareDialogInner {...props} />
     </DialogBoundary>
   )
@@ -171,40 +179,16 @@ function ShareDialogInner({
     <>
       <div className="rf-modal-backdrop" onClick={onClose} />
       <div
-        className="rf-modal"
+        className="rf-modal w-[min(560px,calc(100vw-32px))]"
         role="dialog"
         aria-modal="true"
-        style={{ width: 'min(560px, calc(100vw - 32px))' }}
       >
-        <header
-          style={{
-            padding: '16px 20px 12px',
-            display: 'flex',
-            alignItems: 'center',
-            borderBottom: '1px solid var(--border)',
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <h2
-              style={{
-                margin: 0,
-                fontFamily: 'var(--font-serif)',
-                fontSize: 18,
-                fontWeight: 600,
-                letterSpacing: '-0.01em',
-                color: 'var(--fg)',
-              }}
-            >
+        <header className="pt-4 pr-5 pb-3 pl-5 flex items-center border-b border-border">
+          <div className="flex-1 min-w-0">
+            <h2 className="m-0 font-serif text-lg font-semibold tracking-[-0.01em] text-fg">
               Share transcript
             </h2>
-            <p
-              style={{
-                margin: '2px 0 0',
-                fontSize: 12,
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+            <p className="mt-0.5 mb-0 text-xs text-fg-muted font-sans">
               {MODE_LABEL[mode]} — {MODE_HINT[mode]}
             </p>
           </div>
@@ -212,41 +196,16 @@ function ShareDialogInner({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            style={{
-              border: 'none',
-              background: 'transparent',
-              padding: 6,
-              cursor: 'pointer',
-              color: 'var(--fg-muted)',
-              display: 'inline-flex',
-            }}
+            className="border-none bg-transparent p-1.5 cursor-pointer text-fg-muted inline-flex"
           >
             {I.X(16)}
           </button>
         </header>
 
-        <div
-          style={{
-            padding: 20,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 16,
-            maxHeight: 'calc(100vh - 180px)',
-            overflowY: 'auto',
-          }}
-        >
+        <div className="p-5 flex flex-col gap-4 max-h-[calc(100vh-180px)] overflow-y-auto">
           {canEdit && (
             <Section label="Privacy">
-              <div
-                style={{
-                  display: 'inline-flex',
-                  gap: 0,
-                  padding: 2,
-                  background: 'var(--muted)',
-                  border: '1px solid var(--border)',
-                  borderRadius: 9999,
-                }}
-              >
+              <div className="inline-flex gap-0 p-0.5 bg-muted border border-border rounded-full">
                 {(['private', 'semi-private', 'public'] as const).map((m) => {
                   const on = m === mode
                   return (
@@ -254,18 +213,13 @@ function ShareDialogInner({
                       key={m}
                       onClick={() => handleMode(m)}
                       disabled={modeBusy}
-                      style={{
-                        padding: '5px 12px',
-                        border: 'none',
-                        borderRadius: 9999,
-                        background: on ? 'var(--card)' : 'transparent',
-                        color: on ? 'var(--fg)' : 'var(--fg-muted)',
-                        boxShadow: on ? 'var(--shadow-xs)' : 'none',
-                        fontFamily: 'var(--font-sans)',
-                        fontSize: 12.5,
-                        fontWeight: on ? 600 : 500,
-                        cursor: modeBusy ? 'wait' : 'pointer',
-                      }}
+                      className={cn(
+                        'py-[5px] px-3 border-none rounded-full font-sans text-[12.5px]',
+                        on
+                          ? 'bg-card text-fg shadow-xs font-semibold'
+                          : 'bg-transparent text-fg-muted font-medium',
+                        modeBusy ? 'cursor-wait' : 'cursor-pointer',
+                      )}
                     >
                       {MODE_LABEL[m]}
                     </button>
@@ -276,31 +230,18 @@ function ShareDialogInner({
           )}
 
           <Section label="Share link">
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'stretch',
-                gap: 8,
-              }}
-            >
+            <div className="flex items-stretch gap-2">
               <input
                 readOnly
                 value={url}
                 onFocus={(e) => e.currentTarget.select()}
-                className="rf-input"
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11.5,
-                  height: 34,
-                }}
+                className="rf-input flex-1 min-w-0 font-mono text-[11.5px] h-[34px]"
               />
               <Button
                 variant="outline"
                 size="sm"
                 onClick={copyUrl}
-                style={{ flexShrink: 0 }}
+                className="shrink-0"
               >
                 {I.Copy(13)} Copy
               </Button>
@@ -309,15 +250,9 @@ function ShareDialogInner({
 
           {emailEnabled && (
             <Section label="Email">
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'stretch',
-                  gap: 8,
-                }}
-              >
+              <div className="flex items-stretch gap-2">
                 <input
-                  className="rf-input"
+                  className="rf-input flex-1 h-[34px] text-[13px]"
                   type="email"
                   placeholder="person@example.com"
                   value={emailInput}
@@ -325,14 +260,13 @@ function ShareDialogInner({
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') void handleEmail()
                   }}
-                  style={{ flex: 1, height: 34, fontSize: 13 }}
                 />
                 <Button
                   variant="primary"
                   size="sm"
                   onClick={handleEmail}
                   disabled={sendingEmail || !emailInput.trim()}
-                  style={{ flexShrink: 0 }}
+                  className="shrink-0"
                 >
                   {sendingEmail ? 'Sending…' : 'Send'}
                 </Button>
@@ -342,14 +276,7 @@ function ShareDialogInner({
 
           {canZulip && (
             <Section label="Zulip">
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 1fr auto',
-                  gap: 8,
-                  alignItems: 'stretch',
-                }}
-              >
+              <div className="grid grid-cols-[1fr_1fr_auto] gap-2 items-stretch">
                 <Combobox
                   value={stream}
                   onChange={(v) => {
@@ -372,7 +299,7 @@ function ShareDialogInner({
                   size="sm"
                   onClick={handleZulip}
                   disabled={postingZulip || !stream.trim() || !topic.trim()}
-                  style={{ flexShrink: 0 }}
+                  className="shrink-0"
                 >
                   {postingZulip ? 'Posting…' : 'Post'}
                 </Button>
@@ -381,14 +308,7 @@ function ShareDialogInner({
           )}
         </div>
 
-        <footer
-          style={{
-            padding: '10px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            justifyContent: 'flex-end',
-          }}
-        >
+        <footer className="py-2.5 px-5 border-t border-border flex justify-end">
           <Button variant="ghost" size="sm" onClick={onClose}>
             Close
           </Button>
@@ -403,7 +323,7 @@ function ShareDialogInner({
  * graceful message and a Close button instead of white-screening the app.
  */
 class DialogBoundary extends Component<
-  { onClose: () => void; children: ReactNode },
+  { onClose: () => void; fallbackUrl: string; children: ReactNode },
   { error: Error | null }
 > {
   state: { error: Error | null } = { error: null }
@@ -419,81 +339,27 @@ class DialogBoundary extends Component<
       <>
         <div className="rf-modal-backdrop" onClick={this.props.onClose} />
         <div
-          className="rf-modal"
+          className="rf-modal w-[min(480px,calc(100vw-32px))]"
           role="dialog"
           aria-modal="true"
-          style={{ width: 'min(480px, calc(100vw - 32px))' }}
         >
-          <header
-            style={{
-              padding: '16px 20px 12px',
-              borderBottom: '1px solid var(--border)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 10,
-            }}
-          >
-            <h2
-              style={{
-                margin: 0,
-                fontFamily: 'var(--font-serif)',
-                fontSize: 18,
-                fontWeight: 600,
-                letterSpacing: '-0.01em',
-                color: 'var(--fg)',
-                flex: 1,
-              }}
-            >
+          <header className="pt-4 pr-5 pb-3 pl-5 border-b border-border flex items-center gap-2.5">
+            <h2 className="m-0 font-serif text-lg font-semibold tracking-[-0.01em] text-fg flex-1">
               Share — something went wrong
             </h2>
           </header>
-          <div
-            style={{
-              padding: 20,
-              fontSize: 13,
-              color: 'var(--fg)',
-              fontFamily: 'var(--font-sans)',
-              lineHeight: 1.5,
-            }}
-          >
-            <p style={{ margin: '0 0 10px' }}>
+          <div className="p-5 text-[13px] text-fg font-sans leading-[1.5]">
+            <p className="mt-0 mb-2.5">
               The Share dialog hit an error. Your link is:
             </p>
-            <code
-              style={{
-                display: 'block',
-                padding: 10,
-                background: 'var(--muted)',
-                border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-md)',
-                fontFamily: 'var(--font-mono)',
-                fontSize: 11.5,
-                wordBreak: 'break-all',
-              }}
-            >
-              {typeof window !== 'undefined'
-                ? `${window.location.origin}${window.location.pathname}`
-                : ''}
+            <code className="block p-2.5 bg-muted border border-border rounded-md font-mono text-[11.5px] break-all">
+              {this.props.fallbackUrl}
             </code>
-            <p
-              style={{
-                marginTop: 12,
-                marginBottom: 0,
-                fontSize: 11.5,
-                color: 'var(--fg-muted)',
-              }}
-            >
+            <p className="mt-3 mb-0 text-[11.5px] text-fg-muted">
               {this.state.error.message}
             </p>
           </div>
-          <footer
-            style={{
-              padding: '10px 20px',
-              borderTop: '1px solid var(--border)',
-              display: 'flex',
-              justifyContent: 'flex-end',
-            }}
-          >
+          <footer className="py-2.5 px-5 border-t border-border flex justify-end">
             <Button variant="ghost" size="sm" onClick={this.props.onClose}>
               Close
             </Button>
@@ -507,16 +373,7 @@ class DialogBoundary extends Component<
 function Section({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div>
-      <div
-        style={{
-          fontSize: 10.5,
-          fontWeight: 700,
-          letterSpacing: '0.1em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-muted)',
-          marginBottom: 6,
-        }}
-      >
+      <div className="text-[10.5px] font-bold tracking-widest uppercase text-fg-muted mb-1.5">
         {label}
       </div>
       {children}

--- a/ui/src/components/transcript/StatusPlaceholder.tsx
+++ b/ui/src/components/transcript/StatusPlaceholder.tsx
@@ -10,54 +10,16 @@ const FLAG_NOTE =
 export function StatusPlaceholder({ transcript }: { transcript: Transcript }) {
   const kind = kindFor(transcript)
   return (
-    <div
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        padding: 32,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 18,
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+    <div className="flex flex-col gap-[18px] p-8 bg-card border border-border rounded-lg">
+      <div className="flex items-center gap-3">
         {kind.icon}
-        <h2
-          style={{
-            margin: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 22,
-            fontWeight: 600,
-            letterSpacing: '-0.01em',
-            color: 'var(--fg)',
-          }}
-        >
+        <h2 className="m-0 font-serif text-[22px] font-semibold tracking-[-0.01em] text-fg">
           {kind.title}
         </h2>
       </div>
-      <p
-        style={{
-          margin: 0,
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-sans)',
-          fontSize: 14,
-          lineHeight: 1.55,
-        }}
-      >
-        {kind.body}
-      </p>
+      <p className="m-0 font-sans text-sm leading-[1.55] text-fg-muted">{kind.body}</p>
       {kind.showProgress && <ProgressRow stage={kind.stage!} progress={null} />}
-      <div
-        style={{
-          fontSize: 11.5,
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-mono)',
-          lineHeight: 1.5,
-          paddingTop: 14,
-          borderTop: '1px solid var(--border)',
-        }}
-      >
+      <div className="pt-3.5 border-t border-border font-mono text-[11.5px] leading-[1.5] text-fg-muted">
         {FLAG_NOTE}
       </div>
     </div>
@@ -77,9 +39,7 @@ function kindFor(t: Transcript) {
   if (status === 'idle' && t.source_kind === 'file') {
     return {
       icon: (
-        <span style={{ color: 'var(--fg-muted)', display: 'inline-flex' }}>
-          {I.FileAudio(22)}
-        </span>
+        <span className="inline-flex text-fg-muted">{I.FileAudio(22)}</span>
       ),
       title: 'Waiting for upload',
       body: 'This transcript is pending an audio file. Upload from the transcript detail view on the legacy app, or trigger the upload flow from a new recording.',
@@ -89,9 +49,7 @@ function kindFor(t: Transcript) {
   if (status === 'uploaded' || status === 'processing') {
     return {
       icon: (
-        <span style={{ color: 'var(--status-processing)', display: 'inline-flex' }}>
-          {I.Loader(22)}
-        </span>
+        <span className="inline-flex text-status-processing">{I.Loader(22)}</span>
       ),
       title: 'Processing the recording…',
       body: 'The pipeline is transcribing, diarizing and summarizing. This page will update automatically when the transcript is ready.',
@@ -101,9 +59,7 @@ function kindFor(t: Transcript) {
   }
   return {
     icon: (
-      <span style={{ color: 'var(--fg-muted)', display: 'inline-flex' }}>
-        {I.Clock(22)}
-      </span>
+      <span className="inline-flex text-fg-muted">{I.Clock(22)}</span>
     ),
     title: 'Not ready',
     body: 'This transcript is not in a viewable state yet.',
@@ -113,25 +69,8 @@ function kindFor(t: Transcript) {
 
 function pulseDot() {
   return (
-    <span
-      style={{
-        position: 'relative',
-        display: 'inline-flex',
-        width: 22,
-        height: 22,
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <span
-        style={{
-          width: 10,
-          height: 10,
-          borderRadius: 9999,
-          background: 'var(--status-live)',
-          animation: 'rfPulse 1.4s ease-in-out infinite',
-        }}
-      />
+    <span className="relative inline-flex w-[22px] h-[22px] items-center justify-center">
+      <span className="w-2.5 h-2.5 rounded-full bg-status-live animate-[rfPulse_1.4s_ease-in-out_infinite]" />
     </span>
   )
 }

--- a/ui/src/components/transcript/SummaryPanel.tsx
+++ b/ui/src/components/transcript/SummaryPanel.tsx
@@ -1,17 +1,29 @@
 import { useEffect, useState } from 'react'
-import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
 import { Markdown } from '@/lib/markdown'
 
 type Props = {
   summary: string | null | undefined
-  canEdit: boolean
+  /** Controlled edit mode — parent owns the state so it can show its own
+   *  "Edit" action button (e.g. in a tab-nav row). */
+  editing: boolean
+  onEditingChange: (next: boolean) => void
   saving: boolean
   onSave: (next: string) => Promise<void> | void
 }
 
-export function SummaryPanel({ summary, canEdit, saving, onSave }: Props) {
-  const [editing, setEditing] = useState(false)
+/**
+ * Body-only summary view. Renders the Markdown summary, or a textarea
+ * editor when `editing` is true. No card chrome and no header — the
+ * parent (SummaryTranslationTabs) provides those.
+ */
+export function SummaryPanel({
+  summary,
+  editing,
+  onEditingChange,
+  saving,
+  onSave,
+}: Props) {
   const [draft, setDraft] = useState(summary ?? '')
 
   useEffect(() => {
@@ -21,126 +33,64 @@ export function SummaryPanel({ summary, canEdit, saving, onSave }: Props) {
   useEffect(() => {
     if (!editing) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setEditing(false)
+      if (e.key === 'Escape') onEditingChange(false)
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [editing])
+  }, [editing, onEditingChange])
 
   const save = async () => {
     await onSave(draft)
-    setEditing(false)
+    onEditingChange(false)
+  }
+
+  if (editing) {
+    return (
+      <div className="flex flex-col gap-3">
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && e.shiftKey) {
+              e.preventDefault()
+              void save()
+            }
+          }}
+          autoFocus
+          className="w-full min-h-[200px] p-3 font-sans text-[13.5px] leading-[1.55] text-fg bg-bg border border-border rounded-md resize-y outline-none"
+        />
+        <div className="flex gap-2.5 justify-end">
+          <span className="flex-1 self-center text-[11.5px] text-fg-muted font-sans">
+            Shift+Enter to save · Escape to cancel
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onEditingChange(false)}
+            disabled={saving}
+            className="text-fg font-semibold"
+          >
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" onClick={save} disabled={saving}>
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (summary?.trim()) {
+    return (
+      <div className="font-sans text-[13.5px]">
+        <Markdown source={summary} />
+      </div>
+    )
   }
 
   return (
-    <div
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        padding: 20,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-        }}
-      >
-        <h2
-          style={{
-            margin: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 18,
-            fontWeight: 600,
-            letterSpacing: '-0.01em',
-            color: 'var(--fg)',
-          }}
-        >
-          Summary
-        </h2>
-        {canEdit && !editing && (
-          <Button
-            variant="ghost"
-            size="iconSm"
-            onClick={() => setEditing(true)}
-            title="Edit summary"
-          >
-            {I.Edit(14)}
-          </Button>
-        )}
-      </div>
-
-      {editing ? (
-        <>
-          <textarea
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && e.shiftKey) {
-                e.preventDefault()
-                void save()
-              }
-            }}
-            autoFocus
-            style={{
-              width: '100%',
-              minHeight: 200,
-              padding: 12,
-              fontFamily: 'var(--font-sans)',
-              fontSize: 13.5,
-              lineHeight: 1.55,
-              color: 'var(--fg)',
-              background: 'var(--bg)',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-md)',
-              resize: 'vertical',
-              outline: 'none',
-            }}
-          />
-          <div
-            style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}
-          >
-            <span
-              style={{
-                flex: 1,
-                alignSelf: 'center',
-                fontSize: 11.5,
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
-              Shift+Enter to save · Escape to cancel
-            </span>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setEditing(false)}
-              disabled={saving}
-              style={{ color: 'var(--fg)', fontWeight: 600 }}
-            >
-              Cancel
-            </Button>
-            <Button variant="primary" size="sm" onClick={save} disabled={saving}>
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
-          </div>
-        </>
-      ) : summary?.trim() ? (
-        <div style={{ fontFamily: 'var(--font-sans)', fontSize: 13.5 }}>
-          <Markdown source={summary} />
-        </div>
-      ) : (
-        <div
-          style={{ fontSize: 13, color: 'var(--fg-muted)', fontStyle: 'italic' }}
-        >
-          No summary available yet.
-        </div>
-      )}
+    <div className="text-[13px] text-fg-muted italic">
+      No summary available yet.
     </div>
   )
 }

--- a/ui/src/components/transcript/SummaryTranslationTabs.tsx
+++ b/ui/src/components/transcript/SummaryTranslationTabs.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from 'react'
+import type { components } from '@/api/schema'
+import { I } from '@/components/icons'
+import { Button } from '@/components/ui/primitives'
+import { cn } from '@/lib/utils'
+import { SummaryPanel } from './SummaryPanel'
+import { TranslationPanel } from './TranslationPanel'
+
+type Topic = components['schemas']['GetTranscriptTopic']
+type Participant = components['schemas']['Participant']
+
+type Tab = 'summary' | 'translation'
+
+type Props = {
+  summary: string | null | undefined
+  topics: Topic[]
+  participants: Participant[]
+  sourceLanguage: string | null | undefined
+  targetLanguage: string | null | undefined
+  canEdit: boolean
+  saving: boolean
+  onSaveSummary: (next: string) => Promise<void> | void
+  onSeek: (seconds: number) => void
+}
+
+/**
+ * Two-tab right-column card for the transcript detail view: "Summary"
+ * (editable Markdown blob) and "Translation" (per-segment translated
+ * transcript, mirrors the source topics+segments). The Translation tab
+ * is only mounted when the transcript was created with a target
+ * language different from its source, or when at least one segment
+ * already has a translation.
+ */
+export function SummaryTranslationTabs({
+  summary,
+  topics,
+  participants,
+  sourceLanguage,
+  targetLanguage,
+  canEdit,
+  saving,
+  onSaveSummary,
+  onSeek,
+}: Props) {
+  const [tab, setTab] = useState<Tab>('summary')
+  const [editing, setEditing] = useState(false)
+
+  const hasAnyTranslation = useMemo(
+    () =>
+      topics.some((t) =>
+        (t.segments ?? []).some((s) => s.translation && s.translation.trim()),
+      ),
+    [topics],
+  )
+  const translationRequested = Boolean(
+    targetLanguage && targetLanguage !== sourceLanguage,
+  )
+  const showTranslationTab = translationRequested || hasAnyTranslation
+
+  // If the translation tab disappears while it's active (e.g. data refresh
+  // before any translated segment arrives, then transcript ends without
+  // one), drop back to summary so the user isn't staring at an empty pane.
+  if (tab === 'translation' && !showTranslationTab) {
+    setTab('summary')
+  }
+
+  const switchTab = (next: Tab) => {
+    if (next === tab) return
+    setEditing(false)
+    setTab(next)
+  }
+
+  const showEditAction = tab === 'summary' && canEdit && !editing
+
+  return (
+    <div className="bg-card border border-border rounded-lg flex flex-col">
+      <div className="flex items-center justify-between gap-2 px-5 pt-2 border-b border-border">
+        <div className="flex gap-0">
+          <TabButton active={tab === 'summary'} onClick={() => switchTab('summary')}>
+            Summary
+          </TabButton>
+          {showTranslationTab && (
+            <TabButton
+              active={tab === 'translation'}
+              onClick={() => switchTab('translation')}
+            >
+              Translation
+              {targetLanguage && (
+                <span className="ml-1.5 font-mono text-[10px] text-fg-muted uppercase">
+                  {targetLanguage}
+                </span>
+              )}
+            </TabButton>
+          )}
+        </div>
+        {showEditAction && (
+          <Button
+            variant="ghost"
+            size="iconSm"
+            onClick={() => setEditing(true)}
+            title="Edit summary"
+          >
+            {I.Edit(14)}
+          </Button>
+        )}
+      </div>
+
+      <div className="p-5">
+        {tab === 'summary' ? (
+          <SummaryPanel
+            summary={summary}
+            editing={editing}
+            onEditingChange={setEditing}
+            saving={saving}
+            onSave={onSaveSummary}
+          />
+        ) : (
+          <TranslationPanel
+            topics={topics}
+            participants={participants}
+            onSeek={onSeek}
+            hasTranslationRequest={translationRequested}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'relative px-3.5 pt-2 pb-2.5 border-none bg-transparent font-sans text-[13px] font-medium cursor-pointer -mb-px border-b-2 inline-flex items-center',
+        active ? 'text-fg border-primary' : 'text-fg-muted border-transparent',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/ui/src/components/transcript/TopicsList.tsx
+++ b/ui/src/components/transcript/TopicsList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { components } from '@/api/schema'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { fmtDur } from '@/lib/format'
 
 type Topic = components['schemas']['GetTranscriptTopic']
@@ -24,21 +25,13 @@ export function TopicsList({
 }: Props) {
   if (topics.length === 0) {
     return (
-      <div
-        style={{
-          padding: '40px 20px',
-          textAlign: 'center',
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-sans)',
-          fontSize: 13,
-        }}
-      >
+      <div className="px-5 py-10 text-center text-fg-muted font-sans text-[13px]">
         No topics yet.
       </div>
     )
   }
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <div className="flex flex-col">
       {topics.map((t, i) => (
         <TopicItem
           key={t.id ?? i}
@@ -91,96 +84,45 @@ function TopicItem({
     <div
       ref={ref}
       data-active={highlight ? 'true' : undefined}
-      style={{
-        borderBottom: '1px solid var(--border)',
-        background: 'transparent',
-      }}
+      className="border-b border-border bg-transparent"
     >
       <button
         onClick={() => {
           onSeek(started)
           setOpen((v) => !v)
         }}
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 12,
-          padding: '14px 20px',
-          background: highlight ? 'var(--accent)' : 'var(--muted)',
-          border: 'none',
-          borderBottom: open ? '1px solid var(--border)' : 'none',
-          cursor: 'pointer',
-          textAlign: 'left',
-          fontFamily: 'var(--font-sans)',
-          color: 'var(--fg)',
-          transition: 'background var(--dur-fast) var(--ease-default)',
-        }}
+        className={cn(
+          'w-full flex items-center gap-3 px-5 py-3.5 border-none cursor-pointer text-left font-sans text-fg transition-[background] duration-[var(--dur-fast)] ease-[var(--ease-default)]',
+          highlight ? 'bg-accent' : 'bg-muted',
+          open ? 'border-b border-border' : '',
+        )}
       >
         <span
-          style={{
-            transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
-            transition: 'transform var(--dur-fast)',
-            color: 'var(--fg-muted)',
-            display: 'inline-flex',
-          }}
+          className={cn(
+            'transition-transform duration-[var(--dur-fast)] text-fg-muted inline-flex',
+            open ? 'rotate-90' : 'rotate-0',
+          )}
         >
           {I.ChevronRight(14)}
         </span>
-        <span
-          style={{
-            flex: 1,
-            minWidth: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 15,
-            fontWeight: 600,
-            letterSpacing: '-0.005em',
-            color: 'var(--fg)',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
+        <span className="flex-1 min-w-0 font-serif text-[15px] font-semibold tracking-[-0.005em] text-fg whitespace-nowrap overflow-hidden text-ellipsis">
           {topic.title}
         </span>
-        <span
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 11,
-            color: 'var(--fg-muted)',
-          }}
-        >
+        <span className="font-mono text-[11px] text-fg-muted">
           {fmtTimestamp(started)}
           {topic.duration && topic.duration > 0 ? ` · ${fmtDur(Math.floor(topic.duration))}` : ''}
         </span>
       </button>
 
       {open && (
-        <div
-          style={{
-            padding: '14px 20px 18px 46px',
-            fontFamily: 'var(--font-sans)',
-            fontSize: 13.5,
-            lineHeight: 1.55,
-            color: 'var(--fg)',
-            background: 'var(--card)',
-          }}
-        >
+        <div className="pt-3.5 pr-5 pb-[18px] pl-[46px] font-sans text-[13.5px] leading-[1.55] text-fg bg-card">
           {topic.summary?.trim() && (
-            <div
-              style={{
-                fontStyle: 'italic',
-                color: 'var(--fg-muted)',
-                marginBottom: 12,
-                paddingLeft: 10,
-                borderLeft: '2px solid var(--border)',
-              }}
-            >
+            <div className="italic text-fg-muted mb-3 pl-2.5 border-l-2 border-border">
               {topic.summary}
             </div>
           )}
           {segments.length > 0 ? (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div className="flex flex-col gap-2">
               {segments.map((seg, i) => (
                 <TopicSegment
                   key={i}
@@ -191,9 +133,9 @@ function TopicItem({
               ))}
             </div>
           ) : topic.transcript?.trim() ? (
-            <div style={{ whiteSpace: 'pre-wrap' }}>{topic.transcript}</div>
+            <div className="whitespace-pre-wrap">{topic.transcript}</div>
           ) : (
-            <div style={{ color: 'var(--fg-muted)', fontSize: 12 }}>No transcript.</div>
+            <div className="text-fg-muted text-xs">No transcript.</div>
           )}
         </div>
       )}
@@ -213,35 +155,28 @@ function TopicSegment({
   const name = speakerNameFor(segment.speaker, participants)
   const color = speakerColor(segment.speaker, Math.max(participants.length, 1))
   return (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+    <div className="flex items-start gap-2.5">
       <button
         onClick={() => onSeek(segment.start)}
         title="Seek to this moment"
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--fg-muted)',
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          padding: 0,
-          minWidth: 44,
-          textAlign: 'left',
-        }}
+        className="font-mono text-[11px] text-fg-muted bg-transparent border-none cursor-pointer p-0 min-w-[44px] text-left"
       >
         {fmtTimestamp(segment.start)}
       </button>
       <span
-        style={{
-          fontWeight: 600,
-          color,
-          flexShrink: 0,
-          minWidth: 0,
-        }}
+        className="font-semibold shrink-0 min-w-0"
+        style={{ color }}
       >
         {name}:
       </span>
-      <span style={{ flex: 1, minWidth: 0 }}>{segment.text}</span>
+      <div className="flex-1 min-w-0">
+        <div>{segment.text}</div>
+        {segment.translation && (
+          <div className="text-fg-muted italic text-sm mt-0.5">
+            {segment.translation}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/ui/src/components/transcript/TranscriptHeader.tsx
+++ b/ui/src/components/transcript/TranscriptHeader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { components } from '@/api/schema'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { Button, RowMenuTrigger, StatusBadge } from '@/components/ui/primitives'
 import type { TranscriptStatus as UiStatus } from '@/components/ui/primitives'
 
@@ -87,17 +88,7 @@ export function TranscriptHeader({
   }
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: '16px 20px',
-        borderBottom: '1px solid var(--border)',
-        background: 'var(--card)',
-        borderRadius: 'var(--radius-lg) var(--radius-lg) 0 0',
-      }}
-    >
+    <div className="flex items-center gap-3 px-5 py-4 border-b border-border bg-card rounded-t-lg">
       {editing ? (
         <input
           ref={inputRef}
@@ -114,38 +105,15 @@ export function TranscriptHeader({
             }
           }}
           onBlur={() => void commit()}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 22,
-            fontWeight: 600,
-            letterSpacing: '-0.02em',
-            color: 'var(--fg)',
-            background: 'var(--bg)',
-            border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-sm)',
-            padding: '4px 8px',
-            outline: 'none',
-          }}
+          className="flex-1 min-w-0 font-serif text-[22px] font-semibold tracking-[-0.02em] text-fg bg-bg border border-border rounded-sm px-2 py-1 outline-none"
         />
       ) : (
         <h1
           onClick={startEdit}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            margin: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 22,
-            fontWeight: 600,
-            letterSpacing: '-0.02em',
-            color: 'var(--fg)',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            cursor: canEdit ? 'text' : 'default',
-          }}
+          className={cn(
+            'flex-1 min-w-0 m-0 font-serif text-[22px] font-semibold tracking-[-0.02em] text-fg whitespace-nowrap overflow-hidden text-ellipsis',
+            canEdit ? 'cursor-text' : 'cursor-default',
+          )}
           title={canEdit ? 'Click to rename' : undefined}
         >
           {titleFor(transcript)}

--- a/ui/src/components/transcript/TranslationPanel.tsx
+++ b/ui/src/components/transcript/TranslationPanel.tsx
@@ -1,0 +1,108 @@
+import type { components } from '@/api/schema'
+import { fmtDur } from '@/lib/format'
+
+type Topic = components['schemas']['GetTranscriptTopic']
+type Segment = components['schemas']['GetTranscriptSegmentTopic']
+type Participant = components['schemas']['Participant']
+
+type Props = {
+  topics: Topic[]
+  participants: Participant[]
+  onSeek: (seconds: number) => void
+  /** Indicates translation was requested for this transcript. Drives the
+   *  empty-state copy when no segments carry a translation yet. */
+  hasTranslationRequest: boolean
+}
+
+/**
+ * Body-only translated-transcript view. Mirrors TopicsList but renders
+ * only the translation per segment (skipping segments that don't have
+ * one). Used as the "Translation" tab content next to the summary.
+ */
+export function TranslationPanel({
+  topics,
+  participants,
+  onSeek,
+  hasTranslationRequest,
+}: Props) {
+  const renderable = topics
+    .map((t) => ({
+      topic: t,
+      segments: (t.segments ?? []).filter((s): s is Segment & { translation: string } =>
+        Boolean(s.translation && s.translation.trim()),
+      ),
+    }))
+    .filter(({ segments }) => segments.length > 0)
+
+  if (renderable.length === 0) {
+    return (
+      <div className="text-[13px] text-fg-muted italic">
+        {hasTranslationRequest
+          ? 'Translation will appear here once processing finishes.'
+          : 'No translation available for this transcript.'}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {renderable.map(({ topic, segments }) => (
+        <div key={topic.id} className="flex flex-col gap-2.5">
+          {topic.title && (
+            <div className="font-serif text-[15px] font-semibold tracking-[-0.005em] text-fg">
+              {topic.title}
+            </div>
+          )}
+          <div className="flex flex-col gap-2">
+            {segments.map((s, i) => (
+              <TranslatedSegment
+                key={`${topic.id}-${i}`}
+                segment={s}
+                participants={participants}
+                onSeek={onSeek}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TranslatedSegment({
+  segment,
+  participants,
+  onSeek,
+}: {
+  segment: Segment & { translation: string }
+  participants: Participant[]
+  onSeek: (seconds: number) => void
+}) {
+  const name = speakerNameFor(segment.speaker, participants)
+  return (
+    <div className="flex items-start gap-2.5">
+      <button
+        onClick={() => onSeek(segment.start)}
+        title="Seek to this moment"
+        className="font-mono text-[11px] text-fg-muted bg-transparent border-none cursor-pointer p-0 min-w-[44px] text-left shrink-0"
+      >
+        {fmtTimestamp(segment.start)}
+      </button>
+      <span className="font-semibold shrink-0 text-fg-muted text-[13px]">
+        {name}:
+      </span>
+      <span className="flex-1 min-w-0 text-[13.5px] leading-[1.55] text-fg">
+        {segment.translation}
+      </span>
+    </div>
+  )
+}
+
+function speakerNameFor(speaker: number, participants: Participant[]): string {
+  const found = participants.find((p) => p.speaker === speaker)
+  return found?.name?.trim() || `Speaker ${speaker}`
+}
+
+function fmtTimestamp(seconds: number): string {
+  return fmtDur(Math.floor(seconds))
+}

--- a/ui/src/components/transcript/VideoPanel.tsx
+++ b/ui/src/components/transcript/VideoPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/primitives'
 
 type Props = {
@@ -52,62 +53,29 @@ export function VideoPanel({ transcriptId, enabled }: Props) {
   if (!enabled) return null
 
   return (
-    <div
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-      }}
-    >
+    <div className="bg-card border border-border rounded-lg">
       <button
         onClick={() => setOpen((v) => !v)}
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          padding: '12px 16px',
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          fontFamily: 'var(--font-sans)',
-          color: 'var(--fg)',
-        }}
+        className="w-full flex items-center gap-2.5 px-4 py-3 bg-transparent border-none cursor-pointer font-sans text-fg"
       >
         <span
-          style={{
-            transform: open ? 'rotate(90deg)' : 'rotate(0)',
-            transition: 'transform var(--dur-fast)',
-            color: 'var(--fg-muted)',
-            display: 'inline-flex',
-          }}
+          className={cn(
+            'inline-flex text-fg-muted transition-transform duration-[var(--dur-fast)]',
+            open ? 'rotate-90' : 'rotate-0',
+          )}
         >
           {I.ChevronRight(14)}
         </span>
-        <span style={{ flex: 1, fontWeight: 600, fontSize: 14 }}>Video recording</span>
-        <span style={{ color: 'var(--fg-muted)', fontSize: 12 }}>
-          {open ? 'Hide' : 'Show'}
-        </span>
+        <span className="flex-1 font-semibold text-sm">Video recording</span>
+        <span className="text-fg-muted text-xs">{open ? 'Hide' : 'Show'}</span>
       </button>
       {open && (
-        <div style={{ padding: 16, paddingTop: 0 }}>
+        <div className="px-4 pb-4">
           {loading && (
-            <div
-              style={{ padding: 20, textAlign: 'center', color: 'var(--fg-muted)' }}
-            >
-              Loading video…
-            </div>
+            <div className="p-5 text-center text-fg-muted">Loading video…</div>
           )}
           {error && (
-            <div
-              style={{
-                padding: 12,
-                color: 'var(--destructive)',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
+            <div className="p-3 text-destructive flex items-center gap-1.5">
               {I.AlertTriangle(14)} {error}
             </div>
           )}
@@ -115,11 +83,7 @@ export function VideoPanel({ transcriptId, enabled }: Props) {
             <video
               src={blobUrl}
               controls
-              style={{
-                width: '100%',
-                borderRadius: 'var(--radius-md)',
-                background: 'var(--gh-off-black)',
-              }}
+              className="w-full rounded-md bg-[var(--gh-off-black)]"
             >
               {/* captions not wired yet */}
             </video>
@@ -128,7 +92,7 @@ export function VideoPanel({ transcriptId, enabled }: Props) {
             variant="ghost"
             size="sm"
             onClick={() => setOpen(false)}
-            style={{ marginTop: 8 }}
+            className="mt-2"
           >
             {I.ChevronLeft(12)} Collapse
           </Button>

--- a/ui/src/components/transcript/WaveformCanvas.tsx
+++ b/ui/src/components/transcript/WaveformCanvas.tsx
@@ -43,23 +43,14 @@ export function WaveformCanvas({
 
   return (
     <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: 72,
-        borderRadius: 'var(--radius-md)',
-        background: 'var(--muted)',
-        border: '1px solid var(--border)',
-        overflow: 'hidden',
-        cursor: 'pointer',
-      }}
+      className="relative w-full h-[72px] rounded-md bg-muted border border-border overflow-hidden cursor-pointer"
       onClick={(e) => {
         const rect = e.currentTarget.getBoundingClientRect()
         const x = e.clientX - rect.left
         onSeek(Math.max(0, Math.min(1, x / rect.width)))
       }}
     >
-      <canvas ref={ref} style={{ width: '100%', height: '100%', display: 'block' }} />
+      <canvas ref={ref} className="w-full h-full block" />
     </div>
   )
 }

--- a/ui/src/components/ui/Combobox.tsx
+++ b/ui/src/components/ui/Combobox.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
 import { createPortal } from 'react-dom'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 
 type Props = {
   value: string
@@ -72,11 +73,11 @@ export function Combobox({
     : options
 
   return (
-    <div ref={wrapRef} style={{ position: 'relative', width: '100%' }}>
-      <div style={{ position: 'relative', display: 'flex' }}>
+    <div ref={wrapRef} className="relative w-full">
+      <div className="relative flex">
         <input
           ref={inputRef}
-          className="rf-input"
+          className="rf-input flex-1 pr-[30px] min-w-0"
           type="text"
           disabled={disabled}
           placeholder={placeholder}
@@ -86,12 +87,7 @@ export function Combobox({
             if (!open) setOpen(true)
           }}
           onFocus={() => setOpen(true)}
-          style={{
-            flex: 1,
-            paddingRight: 30,
-            minWidth: 0,
-            ...(inputStyle ?? {}),
-          }}
+          style={inputStyle}
         />
         <button
           type="button"
@@ -102,22 +98,10 @@ export function Combobox({
           }}
           disabled={disabled}
           aria-label="Toggle suggestions"
-          style={{
-            position: 'absolute',
-            right: 4,
-            top: '50%',
-            transform: 'translateY(-50%)',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 22,
-            height: 22,
-            border: 'none',
-            background: 'transparent',
-            color: 'var(--fg-muted)',
-            cursor: disabled ? 'not-allowed' : 'pointer',
-            borderRadius: 3,
-          }}
+          className={cn(
+            'absolute right-1 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-[22px] h-[22px] border-none bg-transparent text-fg-muted rounded-[3px]',
+            disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+          )}
         >
           {I.ChevronDown(12)}
         </button>
@@ -128,33 +112,17 @@ export function Combobox({
           <ul
             ref={listRef}
             role="listbox"
+            className="m-0 p-1 bg-card border border-border rounded-md shadow-md list-none max-h-60 overflow-y-auto font-sans text-[12.5px]"
             style={{
               position: 'fixed',
               left: rect.left,
               top: rect.top,
               width: rect.width,
-              margin: 0,
-              padding: 4,
-              background: 'var(--card)',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-md)',
-              boxShadow: 'var(--shadow-md)',
-              listStyle: 'none',
-              maxHeight: 240,
-              overflowY: 'auto',
               zIndex: 9999,
-              fontFamily: 'var(--font-sans)',
-              fontSize: 12.5,
             }}
           >
             {filtered.length === 0 ? (
-              <li
-                style={{
-                  padding: '6px 10px',
-                  color: 'var(--fg-muted)',
-                  fontStyle: 'italic',
-                }}
-              >
+              <li className="px-2.5 py-1.5 text-fg-muted italic">
                 {options.length === 0 ? 'No options available' : 'No matches'}
               </li>
             ) : (
@@ -168,13 +136,10 @@ export function Combobox({
                     onChange(o)
                     setOpen(false)
                   }}
-                  style={{
-                    padding: '6px 10px',
-                    borderRadius: 'var(--radius-sm)',
-                    cursor: 'pointer',
-                    color: 'var(--fg)',
-                    background: o === value ? 'var(--muted)' : 'transparent',
-                  }}
+                  className={cn(
+                    'px-2.5 py-1.5 rounded-sm cursor-pointer text-fg',
+                    o === value ? 'bg-muted' : 'bg-transparent',
+                  )}
                   onMouseEnter={(e) => {
                     e.currentTarget.style.background = 'var(--muted)'
                   }}

--- a/ui/src/components/ui/primitives.tsx
+++ b/ui/src/components/ui/primitives.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 
 export type TranscriptStatus = 'live' | 'ended' | 'processing' | 'uploading' | 'failed' | 'idle'
 
@@ -23,46 +24,37 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   ref?: Ref<HTMLButtonElement>
 }
 
+const BUTTON_BASE =
+  'inline-flex items-center justify-center gap-2 font-sans font-medium whitespace-nowrap no-underline rounded-md border border-transparent cursor-pointer transition-all duration-[var(--dur-normal)] ease-[var(--ease-default)]'
+
+const BUTTON_SIZE: Record<ButtonSize, string> = {
+  xs: 'h-[26px] px-2 text-xs',
+  sm: 'h-[30px] px-2.5 text-[13px]',
+  md: 'h-9 px-3.5 text-sm',
+  icon: 'h-8 w-8 p-0',
+  iconSm: 'h-7 w-7 p-0',
+}
+
+const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+  primary: 'bg-primary text-primary-fg shadow-xs',
+  secondary: 'bg-secondary text-secondary-fg border-border',
+  outline: 'bg-card text-fg border-border shadow-xs',
+  ghost: 'bg-transparent text-fg-muted',
+  danger: 'bg-transparent text-destructive',
+}
+
 export function Button({
   variant = 'primary',
   size = 'md',
-  style,
+  className,
   children,
   ref,
   ...rest
 }: ButtonProps) {
-  const base: CSSProperties = {
-    fontFamily: 'var(--font-sans)',
-    fontWeight: 500,
-    border: '1px solid transparent',
-    borderRadius: 'var(--radius-md)',
-    cursor: 'pointer',
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    transition: 'all var(--dur-normal) var(--ease-default)',
-    whiteSpace: 'nowrap',
-    textDecoration: 'none',
-  }
-  const sizes: Record<ButtonSize, CSSProperties> = {
-    xs: { height: 26, padding: '0 8px', fontSize: 12 },
-    sm: { height: 30, padding: '0 10px', fontSize: 13 },
-    md: { height: 36, padding: '0 14px', fontSize: 14 },
-    icon: { height: 32, width: 32, padding: 0 },
-    iconSm: { height: 28, width: 28, padding: 0 },
-  }
-  const variants: Record<ButtonVariant, CSSProperties> = {
-    primary: { background: 'var(--primary)', color: 'var(--primary-fg)', boxShadow: 'var(--shadow-xs)' },
-    secondary: { background: 'var(--secondary)', color: 'var(--secondary-fg)', borderColor: 'var(--border)' },
-    outline: { background: 'var(--card)', color: 'var(--fg)', borderColor: 'var(--border)', boxShadow: 'var(--shadow-xs)' },
-    ghost: { background: 'transparent', color: 'var(--fg-muted)' },
-    danger: { background: 'transparent', color: 'var(--destructive)' },
-  }
   return (
     <button
       ref={ref}
-      style={{ ...base, ...sizes[size], ...variants[variant], ...style }}
+      className={cn(BUTTON_BASE, BUTTON_SIZE[size], BUTTON_VARIANT[variant], className)}
       {...rest}
     >
       {children}
@@ -70,81 +62,56 @@ export function Button({
   )
 }
 
+const STATUS_DOT_BG: Record<TranscriptStatus, string> = {
+  live: 'bg-status-live',
+  ended: 'bg-status-ok',
+  processing: 'bg-status-processing',
+  uploading: 'bg-status-processing',
+  failed: 'bg-status-failed',
+  idle: 'bg-status-idle',
+}
+
 export function StatusDot({ status, size = 8 }: { status: TranscriptStatus; size?: number }) {
-  const map: Record<TranscriptStatus, string> = {
-    live: 'var(--status-live)',
-    ended: 'var(--status-ok)',
-    processing: 'var(--status-processing)',
-    uploading: 'var(--status-processing)',
-    failed: 'var(--status-failed)',
-    idle: 'var(--status-idle)',
-  }
+  // Dimensions are runtime-driven (callers pass arbitrary px), so size stays inline.
   return (
     <span
-      style={{
-        display: 'inline-block',
-        width: size,
-        height: size,
-        borderRadius: 9999,
-        background: map[status] ?? map.idle,
-        flexShrink: 0,
-      }}
+      className={cn('inline-block rounded-full shrink-0', STATUS_DOT_BG[status] ?? STATUS_DOT_BG.idle)}
+      style={{ width: size, height: size }}
     />
   )
 }
 
-type BadgeStyle = { color: string; bg: string; bd: string }
+const STATUS_BADGE_VARIANT: Record<TranscriptStatus, string> = {
+  live: 'text-status-live bg-[var(--reflector-accent-tint)] border-[color-mix(in_oklch,var(--status-live)_25%,transparent)]',
+  processing:
+    'text-status-processing bg-[color-mix(in_oklch,var(--status-processing)_10%,transparent)] border-[color-mix(in_oklch,var(--status-processing)_30%,transparent)]',
+  uploading:
+    'text-status-processing bg-[color-mix(in_oklch,var(--status-processing)_10%,transparent)] border-[color-mix(in_oklch,var(--status-processing)_30%,transparent)]',
+  failed:
+    'text-destructive bg-[color-mix(in_oklch,var(--destructive)_10%,transparent)] border-[color-mix(in_oklch,var(--destructive)_25%,transparent)]',
+  ended: 'text-fg-muted bg-muted border-border',
+  idle: 'text-fg-muted bg-muted border-border',
+}
+
+const STATUS_LABEL: Record<TranscriptStatus, string> = {
+  live: 'Live',
+  ended: 'Done',
+  processing: 'Processing',
+  uploading: 'Uploading',
+  failed: 'Failed',
+  idle: 'Idle',
+}
 
 export function StatusBadge({ status }: { status: TranscriptStatus }) {
-  const labels: Record<TranscriptStatus, string> = {
-    live: 'Live',
-    ended: 'Done',
-    processing: 'Processing',
-    uploading: 'Uploading',
-    failed: 'Failed',
-    idle: 'Idle',
-  }
-  const styles: Partial<Record<TranscriptStatus, BadgeStyle>> = {
-    live: { color: 'var(--status-live)', bg: 'rgba(217,94,42,0.08)', bd: 'rgba(217,94,42,0.25)' },
-    processing: {
-      color: 'var(--status-processing)',
-      bg: 'color-mix(in oklch, var(--status-processing) 10%, transparent)',
-      bd: 'color-mix(in oklch, var(--status-processing) 30%, transparent)',
-    },
-    uploading: {
-      color: 'var(--status-processing)',
-      bg: 'color-mix(in oklch, var(--status-processing) 10%, transparent)',
-      bd: 'color-mix(in oklch, var(--status-processing) 30%, transparent)',
-    },
-    failed: {
-      color: 'var(--destructive)',
-      bg: 'color-mix(in oklch, var(--destructive) 10%, transparent)',
-      bd: 'color-mix(in oklch, var(--destructive) 25%, transparent)',
-    },
-    ended: { color: 'var(--fg-muted)', bg: 'var(--muted)', bd: 'var(--border)' },
-  }
-  const s = styles[status] ?? styles.ended!
   return (
     <span
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 6,
-        padding: '1px 8px',
-        height: 20,
-        fontFamily: 'var(--font-sans)',
-        fontSize: 11,
-        fontWeight: 500,
-        color: s.color,
-        background: s.bg,
-        border: '1px solid',
-        borderColor: s.bd,
-        borderRadius: 9999,
-        lineHeight: 1,
-      }}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-px h-5 rounded-full border font-sans text-[11px] font-medium leading-none',
+        STATUS_BADGE_VARIANT[status] ?? STATUS_BADGE_VARIANT.ended,
+      )}
     >
       <StatusDot status={status} size={6} />
-      {labels[status] ?? status}
+      {STATUS_LABEL[status] ?? status}
     </span>
   )
 }
@@ -171,6 +138,8 @@ export function Waveform({
     }
     return out
   }, [seed, bars])
+  // .rf-wave (defined in index.css) lays out the bars; `color` is caller-supplied
+  // and height is computed per-bar — both stay inline.
   return (
     <div className="rf-wave" style={{ color, opacity: active ? 1 : 0.75 }}>
       {heights.map((h, i) => (
@@ -187,15 +156,7 @@ export function Tag({ children, onRemove }: { children: ReactNode; onRemove?: ()
       {onRemove && (
         <button
           onClick={onRemove}
-          style={{
-            border: 'none',
-            background: 'transparent',
-            padding: 0,
-            margin: 0,
-            color: 'var(--fg-muted)',
-            cursor: 'pointer',
-            display: 'inline-flex',
-          }}
+          className="inline-flex border-none bg-transparent text-fg-muted p-0 m-0 cursor-pointer"
         >
           {I.Close(10)}
         </button>
@@ -226,62 +187,37 @@ export function SidebarItem({
   return (
     <button
       onClick={onClick}
-      style={{
-        position: 'relative',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        width: '100%',
-        padding: indent ? '6px 10px 6px 30px' : '7px 10px',
-        fontSize: 13,
-        fontWeight: active ? 600 : 500,
-        color: active ? 'var(--fg)' : 'var(--fg-muted)',
-        background: active ? 'var(--card)' : 'transparent',
-        border: '1px solid',
-        borderColor: active ? 'var(--border)' : 'transparent',
-        boxShadow: active ? 'var(--shadow-xs)' : 'none',
-        borderRadius: 'var(--radius-md)',
-        cursor: 'pointer',
-        textAlign: 'left',
-        fontFamily: 'var(--font-sans)',
-      }}
+      className={cn(
+        'relative flex items-center gap-2.5 w-full font-sans text-[13px] rounded-md cursor-pointer text-left border',
+        indent ? 'py-1.5 pr-2.5 pl-[30px]' : 'px-2.5 py-[7px]',
+        active
+          ? 'text-fg bg-card border-border shadow-xs font-semibold'
+          : 'text-fg-muted bg-transparent border-transparent font-medium',
+      )}
     >
       {active && (
-        <span
-          style={{
-            position: 'absolute',
-            left: -11,
-            top: 6,
-            bottom: 6,
-            width: 2,
-            background: 'var(--primary)',
-            borderRadius: 2,
-          }}
-        />
+        <span className="absolute -left-[11px] top-1.5 bottom-1.5 w-0.5 bg-primary rounded-[2px]" />
       )}
       {icon && (
         <span
-          style={{
-            display: 'inline-flex',
-            color: active ? 'var(--primary)' : 'var(--fg-muted)',
-            opacity: active ? 1 : 0.75,
-          }}
+          className={cn('inline-flex', active ? 'text-primary opacity-100' : 'text-fg-muted opacity-75')}
         >
           {icon}
         </span>
       )}
-      <span style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-        {label}
-      </span>
-      {dot && <span style={{ width: 6, height: 6, borderRadius: 9999, background: dot }} />}
+      <span className="flex-1 whitespace-nowrap overflow-hidden text-ellipsis">{label}</span>
+      {dot && (
+        <span
+          className="w-1.5 h-1.5 rounded-full"
+          style={{ background: dot }}
+        />
+      )}
       {count != null && (
         <span
-          style={{
-            fontSize: 10,
-            fontWeight: 500,
-            fontFamily: 'var(--font-mono)',
-            color: active ? 'var(--fg)' : 'var(--fg-muted)',
-          }}
+          className={cn(
+            'text-[10px] font-medium font-mono',
+            active ? 'text-fg' : 'text-fg-muted',
+          )}
         >
           {count}
         </span>
@@ -293,19 +229,7 @@ export function SidebarItem({
 
 export function SectionLabel({ children, action }: { children: ReactNode; action?: ReactNode }) {
   return (
-    <div
-      style={{
-        padding: '0 10px 6px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        fontSize: 10,
-        fontWeight: 600,
-        letterSpacing: '.1em',
-        textTransform: 'uppercase',
-        color: 'var(--fg-muted)',
-      }}
-    >
+    <div className="flex items-center justify-between px-2.5 pb-1.5 text-[10px] font-semibold uppercase tracking-widest text-fg-muted">
       <span>{children}</span>
       {action}
     </div>
@@ -324,69 +248,30 @@ export function ProgressRow({
   const pct = Math.round((progress ?? 0) * 100)
   return (
     <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '6px 10px',
-        marginTop: 2,
-        background: 'color-mix(in oklch, var(--status-processing) 6%, var(--card))',
-        border: '1px solid color-mix(in oklch, var(--status-processing) 22%, transparent)',
-        borderRadius: 'var(--radius-sm)',
-        fontFamily: 'var(--font-sans)',
-        fontSize: 11.5,
-      }}
+      className={cn(
+        'flex items-center gap-2.5 px-2.5 py-1.5 mt-0.5 rounded-sm font-sans text-[11.5px] border',
+        'bg-[color-mix(in_oklch,var(--status-processing)_6%,var(--card))]',
+        'border-[color-mix(in_oklch,var(--status-processing)_22%,transparent)]',
+      )}
     >
       <span
-        className="rf-spinner"
-        style={{
-          width: 12,
-          height: 12,
-          borderRadius: 9999,
-          flexShrink: 0,
-          border: '2px solid color-mix(in oklch, var(--status-processing) 25%, transparent)',
-          borderTopColor: 'var(--status-processing)',
-          animation: 'rfSpin 0.9s linear infinite',
-        }}
+        className={cn(
+          'rf-spinner w-3 h-3 rounded-full shrink-0 border-2 border-t-status-processing',
+          'border-[color-mix(in_oklch,var(--status-processing)_25%,transparent)]',
+          'border-t-status-processing animate-[rfSpin_0.9s_linear_infinite]',
+        )}
       />
-      <span style={{ color: 'var(--status-processing)', fontWeight: 600 }}>{stage}…</span>
-      <span
-        style={{
-          flex: 1,
-          height: 4,
-          background: 'color-mix(in oklch, var(--status-processing) 15%, transparent)',
-          borderRadius: 2,
-          overflow: 'hidden',
-          position: 'relative',
-        }}
-      >
+      <span className="text-status-processing font-semibold">{stage}…</span>
+      <span className="relative flex-1 h-1 rounded-[2px] overflow-hidden bg-[color-mix(in_oklch,var(--status-processing)_15%,transparent)]">
         <span
-          style={{
-            display: 'block',
-            width: `${pct}%`,
-            height: '100%',
-            background: 'var(--status-processing)',
-            transition: 'width 400ms var(--ease-default)',
-          }}
+          className="block h-full bg-status-processing transition-[width] duration-[400ms] ease-[var(--ease-default)]"
+          style={{ width: `${pct}%` }}
         />
       </span>
-      <span
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          fontWeight: 600,
-          color: 'var(--status-processing)',
-          minWidth: 32,
-          textAlign: 'right',
-        }}
-      >
+      <span className="font-mono text-[11px] font-semibold text-status-processing min-w-[32px] text-right">
         {pct}%
       </span>
-      {eta && (
-        <span style={{ color: 'var(--fg-muted)', fontFamily: 'var(--font-mono)', fontSize: 11 }}>
-          {eta}
-        </span>
-      )}
+      {eta && <span className="text-fg-muted font-mono text-[11px]">{eta}</span>}
     </div>
   )
 }
@@ -443,33 +328,25 @@ export function RowMenu({ items = [], onClose, anchor }: RowMenuProps) {
     }
   }, [onClose])
 
+  // Position values are computed at runtime from the trigger rect; min-width is
+  // a constant the layout math depends on, so both stay inline.
+  const positionStyle: CSSProperties = {
+    top: pos.top,
+    left: pos.left,
+    minWidth: MENU_WIDTH,
+  }
+
   return createPortal(
     <div
       ref={ref}
       role="menu"
       onClick={(e) => e.stopPropagation()}
-      style={{
-        position: 'fixed',
-        top: pos.top,
-        left: pos.left,
-        minWidth: MENU_WIDTH,
-        zIndex: 1000,
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-md)',
-        boxShadow: 'var(--shadow-md)',
-        padding: 4,
-        fontFamily: 'var(--font-sans)',
-      }}
+      className="fixed z-[1000] p-1 bg-card border border-border rounded-md shadow-md font-sans"
+      style={positionStyle}
     >
       {items.map((it, i) => {
         if ('separator' in it) {
-          return (
-            <div
-              key={i}
-              style={{ height: 1, background: 'var(--border)', margin: '4px 2px' }}
-            />
-          )
+          return <div key={i} className="h-px bg-border mx-0.5 my-1" />
         }
         const danger = it.danger
         return (
@@ -482,54 +359,30 @@ export function RowMenu({ items = [], onClose, anchor }: RowMenuProps) {
               it.onClick?.()
               onClose?.()
             }}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 10,
-              width: '100%',
-              padding: '7px 10px',
-              border: 'none',
-              background: 'transparent',
-              fontSize: 13,
-              fontFamily: 'var(--font-sans)',
-              color: it.disabled
-                ? 'var(--fg-muted)'
-                : danger
-                  ? 'var(--destructive)'
-                  : 'var(--fg)',
-              opacity: it.disabled ? 0.5 : 1,
-              borderRadius: 'var(--radius-sm)',
-              textAlign: 'left',
-              cursor: it.disabled ? 'not-allowed' : 'pointer',
-            }}
-            onMouseEnter={(e) => {
-              if (!it.disabled) {
-                e.currentTarget.style.background = danger
-                  ? 'color-mix(in oklch, var(--destructive) 10%, transparent)'
-                  : 'var(--muted)'
-              }
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.background = 'transparent'
-            }}
+            className={cn(
+              'flex items-center gap-2.5 w-full px-2.5 py-[7px] border-none bg-transparent rounded-sm font-sans text-[13px] text-left',
+              it.disabled
+                ? 'text-fg-muted opacity-50 cursor-not-allowed'
+                : cn(
+                    danger
+                      ? 'text-destructive hover:bg-[color-mix(in_oklch,var(--destructive)_10%,transparent)]'
+                      : 'text-fg hover:bg-muted',
+                    'cursor-pointer',
+                  ),
+            )}
           >
             {it.icon && (
               <span
-                style={{
-                  display: 'inline-flex',
-                  flexShrink: 0,
-                  color: danger ? 'var(--destructive)' : 'var(--fg-muted)',
-                }}
+                className={cn(
+                  'inline-flex shrink-0',
+                  danger ? 'text-destructive' : 'text-fg-muted',
+                )}
               >
                 {it.icon}
               </span>
             )}
-            <span style={{ flex: 1, minWidth: 0 }}>{it.label}</span>
-            {it.kbd && (
-              <span className="rf-kbd" style={{ fontSize: 10 }}>
-                {it.kbd}
-              </span>
-            )}
+            <span className="flex-1 min-w-0">{it.label}</span>
+            {it.kbd && <span className="rf-kbd text-[10px]">{it.kbd}</span>}
           </button>
         )
       })}
@@ -564,7 +417,7 @@ export function RowMenuTrigger({
   const [anchor, setAnchor] = useState<DOMRect | null>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   return (
-    <span style={{ display: 'inline-flex' }}>
+    <span className="inline-flex">
       <Button
         ref={triggerRef}
         variant="ghost"

--- a/ui/src/lib/markdown.tsx
+++ b/ui/src/lib/markdown.tsx
@@ -1,4 +1,5 @@
 import { Fragment, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 
 /**
  * Minimal block/inline markdown renderer for transcript summaries.
@@ -75,20 +76,16 @@ function splitBlocks(src: string): Block[] {
   return out
 }
 
+const HEADING_SIZE = ['', 'text-2xl', 'text-xl', 'text-lg', 'text-base', 'text-[15px]', 'text-sm']
+
 function renderBlock(b: Block): ReactNode {
   if (b.kind === 'heading') {
-    const sizes = [0, 24, 20, 18, 16, 15, 14]
     return (
       <div
-        style={{
-          fontFamily: 'var(--font-serif)',
-          fontSize: sizes[b.level] ?? 16,
-          fontWeight: 600,
-          letterSpacing: '-0.01em',
-          color: 'var(--fg)',
-          margin: '18px 0 6px',
-          lineHeight: 1.3,
-        }}
+        className={cn(
+          'font-serif font-semibold tracking-[-0.01em] text-fg mt-[18px] mb-1.5 leading-[1.3]',
+          HEADING_SIZE[b.level] ?? 'text-base',
+        )}
       >
         {renderInline(b.text)}
       </div>
@@ -96,21 +93,14 @@ function renderBlock(b: Block): ReactNode {
   }
   if (b.kind === 'paragraph') {
     return (
-      <p
-        style={{
-          margin: '0 0 10px',
-          lineHeight: 1.55,
-          color: 'var(--fg)',
-          whiteSpace: 'pre-wrap',
-        }}
-      >
+      <p className="mt-0 mb-2.5 leading-[1.55] text-fg whitespace-pre-wrap">
         {renderInline(b.text)}
       </p>
     )
   }
   if (b.kind === 'ul') {
     return (
-      <ul style={{ margin: '0 0 10px', paddingLeft: 20, lineHeight: 1.55 }}>
+      <ul className="mt-0 mb-2.5 pl-5 leading-[1.55]">
         {b.items.map((it, i) => (
           <li key={i}>{renderInline(it)}</li>
         ))}
@@ -118,7 +108,7 @@ function renderBlock(b: Block): ReactNode {
     )
   }
   return (
-    <ol style={{ margin: '0 0 10px', paddingLeft: 22, lineHeight: 1.55 }}>
+    <ol className="mt-0 mb-2.5 pl-[22px] leading-[1.55]">
       {b.items.map((it, i) => (
         <li key={i}>{renderInline(it)}</li>
       ))}
@@ -139,7 +129,7 @@ function renderInline(text: string): ReactNode {
           href={linkMatch[2]}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: 'var(--primary)', textDecoration: 'underline' }}
+          className="text-primary underline"
         >
           {renderInline(linkMatch[1])}
         </a>,
@@ -152,14 +142,7 @@ function renderInline(text: string): ReactNode {
       out.push(
         <code
           key={out.length}
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: '0.9em',
-            padding: '1px 5px',
-            borderRadius: 3,
-            background: 'var(--muted)',
-            border: '1px solid var(--border)',
-          }}
+          className="font-mono text-[0.9em] px-[5px] py-px rounded-[3px] bg-muted border border-border"
         >
           {codeMatch[1]}
         </code>,
@@ -170,7 +153,7 @@ function renderInline(text: string): ReactNode {
     const boldMatch = rest.match(/^\*\*([^*]+)\*\*/)
     if (boldMatch) {
       out.push(
-        <strong key={out.length} style={{ fontWeight: 600 }}>
+        <strong key={out.length} className="font-semibold">
           {renderInline(boldMatch[1])}
         </strong>,
       )
@@ -180,7 +163,7 @@ function renderInline(text: string): ReactNode {
     const italicMatch = rest.match(/^\*([^*]+)\*/) || rest.match(/^_([^_]+)_/)
     if (italicMatch) {
       out.push(
-        <em key={out.length} style={{ fontStyle: 'italic' }}>
+        <em key={out.length} className="italic">
           {renderInline(italicMatch[1])}
         </em>,
       )

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -64,11 +64,12 @@ export const LANG_LABELS: Record<string, string> = {
   es: 'ES',
 }
 
-// Backend's CreateTranscript requires a concrete language string (defaults to
-// "en"). It does NOT support a null/auto-detect mode — Whisper performs the
-// actual detection internally regardless, but the API still needs a seed
-// value. Keep the list to real languages only.
+// Backend's CreateTranscript.source_language is `str | None`. Sending
+// `null` means "auto-detect" — the file pipeline omits the language
+// param so Whisper/Parakeet detects from audio. The UI exposes this as
+// the "Auto" entry; on submit, code 'auto' is mapped to null.
 export const REFLECTOR_LANGS = [
+  { code: 'auto', name: 'Auto-detect', flag: '🌐' },
   { code: 'en', name: 'English', flag: '🇬🇧' },
   { code: 'es', name: 'Spanish', flag: '🇪🇸' },
   { code: 'fr', name: 'French', flag: '🇫🇷' },

--- a/ui/src/pages/ApiKeysPage.tsx
+++ b/ui/src/pages/ApiKeysPage.tsx
@@ -25,55 +25,15 @@ export function ApiKeysPage() {
 
   return (
     <SettingsShell title="Settings" crumb={['settings', 'api-keys']}>
-      <div
-        style={{
-          background: 'var(--card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          boxShadow: 'var(--shadow-xs)',
-          overflow: 'hidden',
-        }}
-      >
-        <header
-          style={{
-            padding: '16px 20px',
-            borderBottom: '1px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-          }}
-        >
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <h1
-              style={{
-                margin: 0,
-                fontFamily: 'var(--font-serif)',
-                fontSize: 20,
-                fontWeight: 600,
-                letterSpacing: '-0.015em',
-                color: 'var(--fg)',
-              }}
-            >
+      <div className="bg-card border border-border rounded-lg shadow-xs overflow-hidden">
+        <header className="px-5 py-4 border-b border-border flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <h1 className="m-0 font-serif text-xl font-semibold tracking-[-0.015em] text-fg">
               API Keys
             </h1>
-            <p
-              style={{
-                margin: '4px 0 0',
-                fontSize: 12.5,
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+            <p className="mt-1 mb-0 text-[12.5px] text-fg-muted font-sans">
               Programmatic access to Reflector. Send the key as the{' '}
-              <code
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11.5,
-                  padding: '1px 4px',
-                  background: 'var(--muted)',
-                  borderRadius: 3,
-                }}
-              >
+              <code className="font-mono text-[11.5px] px-1 py-px bg-muted rounded-[3px]">
                 X-API-Key
               </code>{' '}
               header.
@@ -88,83 +48,36 @@ export function ApiKeysPage() {
           </Button>
         </header>
 
-        <div style={{ padding: '0 20px' }}>
+        <div className="px-5">
           {isLoading ? (
-            <div
-              style={{
-                padding: 32,
-                textAlign: 'center',
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 13,
-              }}
-            >
+            <div className="p-8 text-center text-fg-muted font-sans text-[13px]">
               Loading keys…
             </div>
           ) : isError ? (
-            <div
-              style={{
-                padding: 32,
-                textAlign: 'center',
-                color: 'var(--destructive)',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 13,
-              }}
-            >
+            <div className="p-8 text-center text-destructive font-sans text-[13px]">
               Failed to load keys.
             </div>
           ) : keys.length === 0 ? (
             <EmptyState onCreate={() => setCreateOpen(true)} />
           ) : (
-            <table
-              style={{
-                width: '100%',
-                borderCollapse: 'collapse',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 13,
-              }}
-            >
+            <table className="w-full border-collapse font-sans text-[13px]">
               <thead>
-                <tr
-                  style={{
-                    textAlign: 'left',
-                    color: 'var(--fg-muted)',
-                    fontSize: 11,
-                    letterSpacing: '0.03em',
-                    textTransform: 'uppercase',
-                  }}
-                >
-                  <th style={{ padding: '10px 0', fontWeight: 600 }}>Name</th>
-                  <th style={{ padding: '10px 0', fontWeight: 600 }}>Created</th>
-                  <th style={{ padding: '10px 0', fontWeight: 600, width: 40 }} />
+                <tr className="text-left text-fg-muted text-[11px] tracking-[0.03em] uppercase">
+                  <th className="py-2.5 font-semibold">Name</th>
+                  <th className="py-2.5 font-semibold">Created</th>
+                  <th className="py-2.5 font-semibold w-10" />
                 </tr>
               </thead>
               <tbody>
                 {keys.map((k) => (
-                  <tr
-                    key={k.id}
-                    style={{ borderTop: '1px solid var(--border)' }}
-                  >
-                    <td
-                      style={{
-                        padding: '12px 0',
-                        color: 'var(--fg)',
-                        fontWeight: 500,
-                      }}
-                    >
-                      {k.name || <span style={{ color: 'var(--fg-muted)' }}>Unnamed</span>}
+                  <tr key={k.id} className="border-t border-border">
+                    <td className="py-3 text-fg font-medium">
+                      {k.name || <span className="text-fg-muted">Unnamed</span>}
                     </td>
-                    <td
-                      style={{
-                        padding: '12px 0',
-                        color: 'var(--fg-muted)',
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: 11.5,
-                      }}
-                    >
+                    <td className="py-3 text-fg-muted font-mono text-[11.5px]">
                       {fmtDate(k.created_at)}
                     </td>
-                    <td style={{ padding: '12px 0', textAlign: 'right' }}>
+                    <td className="py-3 text-right">
                       <Button
                         variant="ghost"
                         size="icon"
@@ -211,7 +124,7 @@ export function ApiKeysPage() {
           title="Delete API key?"
           message={
             <>
-              <strong style={{ color: 'var(--fg)' }}>
+              <strong className="text-fg">
                 {deleting.name || 'Unnamed key'}
               </strong>{' '}
               will be revoked immediately. Any service using it will start to fail.
@@ -239,41 +152,14 @@ export function ApiKeysPage() {
 
 function EmptyState({ onCreate }: { onCreate: () => void }) {
   return (
-    <div
-      style={{
-        padding: '48px 20px',
-        textAlign: 'center',
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
-      <div
-        style={{
-          color: 'var(--fg-muted)',
-          display: 'inline-flex',
-          marginBottom: 12,
-        }}
-      >
+    <div className="px-5 py-12 text-center font-sans">
+      <div className="text-fg-muted inline-flex mb-3">
         {I.Shield(28)}
       </div>
-      <div
-        style={{
-          fontSize: 15,
-          fontWeight: 600,
-          color: 'var(--fg)',
-          marginBottom: 4,
-        }}
-      >
+      <div className="text-[15px] font-semibold text-fg mb-1">
         No API keys yet
       </div>
-      <p
-        style={{
-          margin: '0 auto 16px',
-          maxWidth: 380,
-          fontSize: 13,
-          color: 'var(--fg-muted)',
-          lineHeight: 1.5,
-        }}
-      >
+      <p className="mx-auto mt-0 mb-4 max-w-[380px] text-[13px] text-fg-muted leading-[1.5]">
         Generate one to start calling the Reflector API from your own scripts or services.
       </p>
       <Button variant="primary" size="sm" onClick={onCreate}>
@@ -297,50 +183,17 @@ function CreateKeyDialog({
   return (
     <div className="rf-modal-backdrop" onClick={onClose}>
       <div
-        className="rf-modal"
+        className="rf-modal w-[440px] max-w-[92vw]"
         onClick={(e) => e.stopPropagation()}
-        style={{ width: 440, maxWidth: '92vw' }}
       >
-        <header
-          style={{
-            padding: '16px 20px',
-            borderBottom: '1px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          <h2
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 18,
-              fontWeight: 600,
-              letterSpacing: '-0.01em',
-              color: 'var(--fg)',
-              flex: 1,
-            }}
-          >
+        <header className="px-5 py-4 border-b border-border flex items-center">
+          <h2 className="m-0 font-serif text-lg font-semibold tracking-[-0.01em] text-fg flex-1">
             New API key
           </h2>
         </header>
-        <div
-          style={{
-            padding: 20,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 12,
-            fontFamily: 'var(--font-sans)',
-            fontSize: 13,
-          }}
-        >
-          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <span
-              style={{
-                fontSize: 12.5,
-                fontWeight: 500,
-                color: 'var(--fg)',
-              }}
-            >
+        <div className="p-5 flex flex-col gap-3 font-sans text-[13px]">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12.5px] font-medium text-fg">
               Name
             </span>
             <input
@@ -358,25 +211,12 @@ function CreateKeyDialog({
               }}
               disabled={saving}
             />
-            <span
-              style={{
-                fontSize: 11.5,
-                color: 'var(--fg-muted)',
-              }}
-            >
+            <span className="text-[11.5px] text-fg-muted">
               Optional — helps you remember what this key is for.
             </span>
           </label>
         </div>
-        <footer
-          style={{
-            padding: '12px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: 8,
-          }}
-        >
+        <footer className="px-5 py-3 border-t border-border flex justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onClose} disabled={saving}>
             Cancel
           </Button>
@@ -413,94 +253,37 @@ function RevealKeyDialog({
   return (
     <div className="rf-modal-backdrop" onClick={onClose}>
       <div
-        className="rf-modal"
+        className="rf-modal w-[520px] max-w-[92vw]"
         onClick={(e) => e.stopPropagation()}
-        style={{ width: 520, maxWidth: '92vw' }}
       >
-        <header
-          style={{
-            padding: '16px 20px',
-            borderBottom: '1px solid var(--border)',
-          }}
-        >
-          <h2
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 18,
-              fontWeight: 600,
-              letterSpacing: '-0.01em',
-              color: 'var(--fg)',
-            }}
-          >
+        <header className="px-5 py-4 border-b border-border">
+          <h2 className="m-0 font-serif text-lg font-semibold tracking-[-0.01em] text-fg">
             API key created
           </h2>
         </header>
-        <div
-          style={{
-            padding: 20,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 12,
-            fontFamily: 'var(--font-sans)',
-            fontSize: 13,
-            lineHeight: 1.5,
-          }}
-        >
-          <p style={{ margin: 0, color: 'var(--fg)' }}>
+        <div className="p-5 flex flex-col gap-3 font-sans text-[13px] leading-[1.5]">
+          <p className="m-0 text-fg">
             Copy this key now. <strong>It won't be shown again.</strong>
           </p>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'stretch',
-              gap: 8,
-            }}
-          >
-            <code
-              style={{
-                flex: 1,
-                minWidth: 0,
-                padding: '10px 12px',
-                fontFamily: 'var(--font-mono)',
-                fontSize: 12,
-                background: 'var(--muted)',
-                border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-md)',
-                wordBreak: 'break-all',
-                color: 'var(--fg)',
-              }}
-            >
+          <div className="flex items-stretch gap-2">
+            <code className="flex-1 min-w-0 px-3 py-2.5 font-mono text-xs bg-muted border border-border rounded-md break-all text-fg">
               {apiKey.key}
             </code>
             <Button
               variant="outline"
               size="sm"
               onClick={copy}
-              style={{ flexShrink: 0 }}
+              className="shrink-0"
             >
               {I.Copy(13)} Copy
             </Button>
           </div>
-          <p
-            style={{
-              margin: 0,
-              fontSize: 12,
-              color: 'var(--fg-muted)',
-            }}
-          >
-            Use it as the <code style={{ fontFamily: 'var(--font-mono)' }}>X-API-Key</code>{' '}
+          <p className="m-0 text-xs text-fg-muted">
+            Use it as the <code className="font-mono">X-API-Key</code>{' '}
             header on every request.
           </p>
         </div>
-        <footer
-          style={{
-            padding: '12px 20px',
-            borderTop: '1px solid var(--border)',
-            display: 'flex',
-            justifyContent: 'flex-end',
-          }}
-        >
+        <footer className="px-5 py-3 border-t border-border flex justify-end">
           <Button variant="primary" size="sm" onClick={onClose}>
             Done
           </Button>

--- a/ui/src/pages/AuthCallback.tsx
+++ b/ui/src/pages/AuthCallback.tsx
@@ -11,15 +11,7 @@ export function AuthCallbackPage() {
   }, [authenticated, loading, navigate])
 
   return (
-    <div
-      style={{
-        height: '100vh',
-        display: 'grid',
-        placeItems: 'center',
-        color: 'var(--fg-muted)',
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
+    <div className="h-screen grid place-items-center text-fg-muted font-sans">
       Signing you in…
     </div>
   )

--- a/ui/src/pages/BrowsePage.tsx
+++ b/ui/src/pages/BrowsePage.tsx
@@ -74,6 +74,31 @@ export function BrowsePage() {
     onError: (err) => toast.error(messageFor(err, 'Restore failed')),
   })
 
+  const reprocessMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { data, response, error } = await apiClient.POST(
+        '/v1/transcripts/{transcript_id}/process',
+        { params: { path: { transcript_id: id } } },
+      )
+      if (!response.ok) {
+        throw Object.assign(new Error('Reprocess failed'), {
+          detail: extractDetail(error),
+        })
+      }
+      return data as { status?: string } | undefined
+    },
+    onSuccess: (data) => {
+      invalidateList()
+      if (data?.status && data.status !== 'ok') {
+        // Backend returns "already-scheduled" when a run is already in flight.
+        toast.info(data.status)
+      } else {
+        toast.success('Reprocessing started')
+      }
+    },
+    onError: (err) => toast.error(messageFor(err, 'Reprocess failed')),
+  })
+
   const destroyMutation = useMutation({
     mutationFn: async (id: string) => {
       const { response, error } = await apiClient.DELETE(
@@ -209,15 +234,7 @@ export function BrowsePage() {
         />
       }
     >
-      <div
-        style={{
-          background: 'var(--card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          overflow: 'hidden',
-          boxShadow: 'var(--shadow-xs)',
-        }}
-      >
+      <div className="bg-card border border-border rounded-lg overflow-hidden shadow-xs">
         <FilterBar
           filter={filter}
           rooms={rooms}
@@ -233,19 +250,11 @@ export function BrowsePage() {
         />
 
         {isLoading && items.length === 0 ? (
-          <div style={{ padding: 32, textAlign: 'center', color: 'var(--fg-muted)' }}>
+          <div className="p-8 text-center text-fg-muted">
             Loading…
           </div>
         ) : items.length === 0 ? (
-          <div
-            style={{
-              padding: '64px 20px',
-              textAlign: 'center',
-              color: 'var(--fg-muted)',
-              fontFamily: 'var(--font-sans)',
-              fontSize: 13,
-            }}
-          >
+          <div className="px-5 py-16 text-center text-fg-muted font-sans text-[13px]">
             No transcripts to show.
           </div>
         ) : filter.kind === 'trash' ? (
@@ -265,6 +274,7 @@ export function BrowsePage() {
               query={q}
               onSelect={(id) => navigate(`/transcripts/${id}`)}
               onDelete={(x) => setToDelete(x)}
+              onReprocess={(id) => reprocessMutation.mutate(id)}
             />
           ))
         )}
@@ -284,7 +294,7 @@ export function BrowsePage() {
           title="Move to trash?"
           message={
             <>
-              <strong style={{ color: 'var(--fg)' }}>
+              <strong className="text-fg">
                 {toDelete.title || 'Unnamed transcript'}
               </strong>{' '}
               will be moved to the trash. You can restore it later from the trash view.
@@ -303,7 +313,7 @@ export function BrowsePage() {
           title="Destroy permanently?"
           message={
             <>
-              <strong style={{ color: 'var(--fg)' }}>
+              <strong className="text-fg">
                 {toDestroy.title || 'Unnamed transcript'}
               </strong>{' '}
               and all its associated files will be permanently deleted. This can't be undone.

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -74,53 +74,29 @@ export function HomePage() {
         />
       }
     >
-      <div style={{ maxWidth: 560, margin: '20px auto 0', padding: '0 4px 80px' }}>
-        <header style={{ marginBottom: 24 }}>
-          <h1
-            style={{
-              fontFamily: 'var(--font-serif)',
-              fontSize: 32,
-              fontWeight: 600,
-              letterSpacing: '-0.02em',
-              margin: 0,
-              color: 'var(--fg)',
-            }}
-          >
+      <div className="max-w-[560px] mx-auto mt-5 px-1 pb-20">
+        <header className="mb-6">
+          <h1 className="font-serif text-[32px] font-semibold tracking-[-0.02em] m-0 text-fg">
             New transcript
           </h1>
-          <p
-            style={{
-              fontSize: 14,
-              color: 'var(--fg-muted)',
-              marginTop: 6,
-              fontFamily: 'var(--font-sans)',
-            }}
-          >
+          <p className="text-sm text-fg-muted mt-1.5 font-sans">
             Record live or upload a file. You can edit details later.
           </p>
         </header>
 
-        <div
-          style={{
-            background: 'var(--card)',
-            border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-lg)',
-            padding: 24,
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div className="bg-card border border-border rounded-lg p-6">
+          <div className="flex flex-col gap-4">
             <div>
               <label className="rf-label" htmlFor="rf-title">
                 Title
               </label>
               <input
                 id="rf-title"
-                className="rf-input"
+                className="rf-input mt-1.5"
                 type="text"
                 placeholder="e.g. Sprint review — June 12"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                style={{ marginTop: 6 }}
               />
             </div>
 
@@ -134,40 +110,22 @@ export function HomePage() {
             <RoomPicker roomId={roomId} setRoomId={setRoomId} rooms={rooms} />
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              gap: 10,
-              marginTop: 24,
-              paddingTop: 20,
-              borderTop: '1px solid var(--border)',
-            }}
-          >
+          <div className="flex gap-2.5 mt-6 pt-5 border-t border-border">
             <Button
               variant="primary"
               size="md"
               onClick={handleStart}
               disabled={submitting}
-              style={{ flex: 1 }}
+              className="flex-1"
             >
               {I.Mic(14)} {submitting ? 'Starting…' : 'Start recording'}
             </Button>
-            <Button variant="secondary" size="md" onClick={handleUpload} style={{ flex: 1 }}>
+            <Button variant="secondary" size="md" onClick={handleUpload} className="flex-1">
               {I.Upload(14)} Upload audio
             </Button>
           </div>
 
-          <div
-            style={{
-              marginTop: 14,
-              fontSize: 11.5,
-              color: 'var(--fg-muted)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              fontFamily: 'var(--font-sans)',
-            }}
-          >
+          <div className="mt-3.5 text-[11.5px] text-fg-muted flex items-center gap-1.5 font-sans">
             {I.Lock(12)}
             Audio is processed on your infrastructure.
           </div>

--- a/ui/src/pages/LoggedOut.tsx
+++ b/ui/src/pages/LoggedOut.tsx
@@ -18,80 +18,29 @@ export function LoggedOutPage() {
 
   return (
     <>
-      <main
-        style={{
-          maxWidth: 520,
-          margin: '0 auto',
-          minHeight: '100vh',
-          padding: '48px 24px',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          textAlign: 'center',
-        }}
-      >
-        <div
-          style={{
-            width: 72,
-            height: 72,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginBottom: 24,
-            background: 'var(--reflector-accent-tint)',
-            borderRadius: '50%',
-          }}
-        >
+      <main className="max-w-[520px] mx-auto min-h-screen px-6 py-12 flex flex-col items-center justify-center text-center">
+        <div className="w-[72px] h-[72px] flex items-center justify-center mb-6 bg-[var(--reflector-accent-tint)] rounded-full">
           <ReflectorMark size={40} />
         </div>
 
-        <div
-          style={{
-            fontSize: 11,
-            textTransform: 'uppercase',
-            letterSpacing: '0.14em',
-            color: 'var(--fg-muted)',
-            fontFamily: 'var(--font-mono)',
-            marginBottom: 14,
-          }}
-        >
+        <div className="text-[11px] uppercase tracking-[0.14em] text-fg-muted font-mono mb-3.5">
           Reflector · by Greyhaven
         </div>
 
-        <h1
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 44,
-            fontWeight: 600,
-            letterSpacing: '-0.025em',
-            margin: 0,
-            lineHeight: 1.05,
-            color: 'var(--fg)',
-          }}
-        >
+        <h1 className="font-serif text-[44px] font-semibold tracking-[-0.025em] m-0 leading-[1.05] text-fg">
           Transcripts &amp; translation,
           <br />
-          <span style={{ fontStyle: 'italic', color: 'var(--fg-muted)' }}>
+          <span className="italic text-fg-muted">
             on your own infrastructure.
           </span>
         </h1>
 
-        <p
-          style={{
-            fontSize: 15.5,
-            color: 'var(--fg-muted)',
-            marginTop: 18,
-            fontFamily: 'var(--font-sans)',
-            maxWidth: 420,
-            lineHeight: 1.55,
-          }}
-        >
+        <p className="text-[15.5px] text-fg-muted mt-[18px] font-sans max-w-[420px] leading-[1.55]">
           Record meetings, upload audio, translate between 40+ languages. Hosted, operated and
           owned by your team. No third-party AI vendor touches the audio.
         </p>
 
-        <div style={{ display: 'flex', gap: 10, marginTop: 28, alignItems: 'center' }}>
+        <div className="flex gap-2.5 mt-7 items-center">
           <Button variant="primary" size="md" onClick={handleSignIn}>
             Sign in to continue
           </Button>
@@ -100,36 +49,14 @@ export function LoggedOutPage() {
           </Button>
         </div>
 
-        <div
-          style={{
-            marginTop: 48,
-            paddingTop: 24,
-            borderTop: '1px solid var(--border)',
-            width: '100%',
-            display: 'flex',
-            justifyContent: 'space-between',
-            fontSize: 12,
-            color: 'var(--fg-muted)',
-            fontFamily: 'var(--font-sans)',
-          }}
-        >
-          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <div className="mt-12 pt-6 border-t border-border w-full flex justify-between text-xs text-fg-muted font-sans">
+          <span className="inline-flex items-center gap-1.5">
             {I.Lock(12)} Self-hosted
           </span>
           <button
             type="button"
             onClick={() => setPrivacyOpen(true)}
-            style={{
-              background: 'none',
-              border: 'none',
-              padding: 0,
-              color: 'inherit',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              fontSize: 'inherit',
-              textDecoration: 'underline',
-              textUnderlineOffset: 2,
-            }}
+            className="bg-none border-none p-0 text-inherit cursor-pointer font-[inherit] text-[length:inherit] underline underline-offset-2"
           >
             Privacy &amp; retention
           </button>
@@ -137,14 +64,7 @@ export function LoggedOutPage() {
             href="https://greyhaven.co"
             target="_blank"
             rel="noreferrer"
-            style={{
-              color: 'inherit',
-              textDecoration: 'underline',
-              textUnderlineOffset: 2,
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 4,
-            }}
+            className="text-inherit underline underline-offset-2 inline-flex items-center gap-1"
           >
             greyhaven.co {I.ExternalLink(11)}
           </a>
@@ -162,91 +82,44 @@ function PrivacyDialog({ onClose }: { onClose: () => void }) {
     <>
       <div className="rf-modal-backdrop" onClick={onClose} />
       <div className="rf-modal" role="dialog" aria-modal="true">
-        <div
-          style={{
-            padding: '20px 24px 14px',
-            borderBottom: '1px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}
-        >
-          <h2
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 20,
-              fontWeight: 600,
-              letterSpacing: '-0.015em',
-              color: 'var(--fg)',
-            }}
-          >
+        <div className="px-6 pt-5 pb-3.5 border-b border-border flex items-center justify-between">
+          <h2 className="m-0 font-serif text-xl font-semibold tracking-[-0.015em] text-fg">
             Privacy Policy
           </h2>
           <button
             onClick={onClose}
             aria-label="Close"
-            style={{
-              border: 'none',
-              background: 'transparent',
-              color: 'var(--fg-muted)',
-              cursor: 'pointer',
-              padding: 4,
-              borderRadius: 4,
-              display: 'inline-flex',
-            }}
+            className="border-none bg-transparent text-fg-muted cursor-pointer p-1 rounded-sm inline-flex"
           >
             {I.Close(18)}
           </button>
         </div>
-        <div
-          style={{
-            padding: '18px 24px 22px',
-            color: 'var(--fg)',
-            fontFamily: 'var(--font-sans)',
-            fontSize: 14,
-            lineHeight: 1.6,
-            overflowY: 'auto',
-            maxHeight: 'calc(100vh - 180px)',
-          }}
-        >
-          <p
-            style={{
-              marginTop: 0,
-              marginBottom: 14,
-              fontStyle: 'italic',
-              color: 'var(--fg-muted)',
-              fontSize: 13,
-            }}
-          >
+        <div className="px-6 pt-[18px] pb-[22px] text-fg font-sans text-sm leading-[1.6] overflow-y-auto max-h-[calc(100vh-180px)]">
+          <p className="mt-0 mb-3.5 italic text-fg-muted text-[13px]">
             Last updated on September 22, 2023
           </p>
-          <ul style={{ paddingLeft: 18, margin: '0 0 14px' }}>
-            <li style={{ marginBottom: 10 }}>
+          <ul className="pl-[18px] mt-0 mb-3.5">
+            <li className="mb-2.5">
               Recording Consent: By using Reflector, you grant us permission to record your
               interactions for the purpose of showcasing Reflector's capabilities during the All
               In AI conference.
             </li>
-            <li style={{ marginBottom: 10 }}>
+            <li className="mb-2.5">
               Data Access: You will have convenient access to your recorded sessions and
               transcriptions via a unique URL, which remains active for a period of seven days.
               After this time, your recordings and transcripts will be deleted.
             </li>
-            <li style={{ marginBottom: 10 }}>
+            <li className="mb-2.5">
               Data Confidentiality: Rest assured that none of your audio data will be shared with
               third parties.
             </li>
           </ul>
-          <p style={{ margin: 0 }}>
+          <p className="m-0">
             Questions or Concerns: If you have any questions or concerns regarding your data,
             please feel free to reach out to us at{' '}
             <a
               href="mailto:reflector@monadical.com"
-              style={{
-                color: 'var(--primary)',
-                textDecoration: 'underline',
-                textUnderlineOffset: 2,
-              }}
+              className="text-primary underline underline-offset-2"
             >
               reflector@monadical.com
             </a>
@@ -263,57 +136,24 @@ function LearnMoreDialog({ onClose }: { onClose: () => void }) {
     <>
       <div className="rf-modal-backdrop" onClick={onClose} />
       <div className="rf-modal" role="dialog" aria-modal="true">
-        <div
-          style={{
-            padding: '20px 24px 14px',
-            borderBottom: '1px solid var(--border)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}
-        >
-          <h2
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 20,
-              fontWeight: 600,
-              letterSpacing: '-0.015em',
-              color: 'var(--fg)',
-            }}
-          >
+        <div className="px-6 pt-5 pb-3.5 border-b border-border flex items-center justify-between">
+          <h2 className="m-0 font-serif text-xl font-semibold tracking-[-0.015em] text-fg">
             What is Reflector?
           </h2>
           <button
             onClick={onClose}
             aria-label="Close"
-            style={{
-              border: 'none',
-              background: 'transparent',
-              color: 'var(--fg-muted)',
-              cursor: 'pointer',
-              padding: 4,
-              borderRadius: 4,
-              display: 'inline-flex',
-            }}
+            className="border-none bg-transparent text-fg-muted cursor-pointer p-1 rounded-sm inline-flex"
           >
             {I.Close(18)}
           </button>
         </div>
-        <div
-          style={{
-            padding: '18px 24px 22px',
-            color: 'var(--fg)',
-            fontFamily: 'var(--font-sans)',
-            fontSize: 14,
-            lineHeight: 1.6,
-          }}
-        >
-          <p style={{ marginTop: 0 }}>
+        <div className="px-6 pt-[18px] pb-[22px] text-fg font-sans text-sm leading-[1.6]">
+          <p className="mt-0">
             Reflector turns meetings and audio files into searchable transcripts and translations.
             It runs on your infrastructure, so no third-party AI vendor touches the audio.
           </p>
-          <p style={{ marginBottom: 0 }}>
+          <p className="mb-0">
             Record live from your browser, upload existing files, or connect a meeting room. The
             processing pipeline (transcription, diarization, translation, summarization) is
             open-source and self-hosted.

--- a/ui/src/pages/LoginForm.tsx
+++ b/ui/src/pages/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/primitives'
 import { useAuth } from '@/auth/AuthContext'
@@ -29,55 +29,28 @@ export function LoginForm() {
     }
   }
 
-  const inputStyle: CSSProperties = {
-    width: '100%',
-    height: 40,
-    padding: '0 12px',
-    background: 'var(--bg)',
-    border: '1px solid var(--border)',
-    borderRadius: 'var(--radius-md)',
-    color: 'var(--fg)',
-    fontFamily: 'var(--font-sans)',
-    fontSize: 14,
-    outline: 'none',
-  }
+  const inputClass =
+    'w-full h-10 px-3 bg-bg border border-border rounded-md text-fg font-sans text-sm outline-none'
 
   return (
-    <main style={{ maxWidth: 400, margin: '0 auto', padding: '100px 24px 60px' }}>
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 22 }}>
-        <h1
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 32,
-            fontWeight: 600,
-            letterSpacing: '-0.02em',
-            margin: 0,
-            lineHeight: 1.1,
-            color: 'var(--fg)',
-          }}
-        >
+    <main className="max-w-[400px] mx-auto pt-[100px] px-6 pb-[60px]">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-[22px]">
+        <h1 className="font-serif text-3xl font-semibold tracking-[-0.02em] m-0 leading-[1.1] text-fg">
           Log in
         </h1>
 
         {error && (
           <div
             role="alert"
-            style={{
-              fontSize: 13,
-              color: 'var(--destructive)',
-              background: 'color-mix(in srgb, var(--destructive) 8%, transparent)',
-              border: '1px solid color-mix(in srgb, var(--destructive) 25%, transparent)',
-              borderRadius: 'var(--radius-md)',
-              padding: '8px 12px',
-            }}
+            className="text-[13px] text-destructive bg-[color-mix(in_srgb,var(--destructive)_8%,transparent)] border border-[color-mix(in_srgb,var(--destructive)_25%,transparent)] rounded-md px-3 py-2"
           >
             {error}
           </div>
         )}
 
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>
-            Email <span style={{ color: 'var(--destructive)' }}>*</span>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[13px] font-medium text-fg">
+            Email <span className="text-destructive">*</span>
           </span>
           <input
             type="email"
@@ -85,20 +58,20 @@ export function LoginForm() {
             autoFocus
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            style={inputStyle}
+            className={inputClass}
           />
         </label>
 
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>
-            Password <span style={{ color: 'var(--destructive)' }}>*</span>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[13px] font-medium text-fg">
+            Password <span className="text-destructive">*</span>
           </span>
           <input
             type="password"
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            style={inputStyle}
+            className={inputClass}
           />
         </label>
 
@@ -106,7 +79,7 @@ export function LoginForm() {
           type="submit"
           variant="primary"
           disabled={loading}
-          style={{ width: '100%', height: 40 }}
+          className="w-full h-10"
         >
           {loading ? 'Signing in…' : 'Log in'}
         </Button>
@@ -114,16 +87,7 @@ export function LoginForm() {
         <button
           type="button"
           onClick={() => navigate('/welcome')}
-          style={{
-            background: 'transparent',
-            border: 'none',
-            color: 'var(--fg-muted)',
-            fontSize: 13,
-            fontFamily: 'var(--font-sans)',
-            cursor: 'pointer',
-            textAlign: 'center',
-            padding: 0,
-          }}
+          className="bg-transparent border-none text-fg-muted text-[13px] font-sans cursor-pointer text-center p-0"
         >
           ← Back
         </button>

--- a/ui/src/pages/RecordPage.tsx
+++ b/ui/src/pages/RecordPage.tsx
@@ -5,6 +5,7 @@ import { MinimalHeader } from '@/components/layout/MinimalHeader'
 import { LiveLevelMeter } from '@/components/record/LiveLevelMeter'
 import { Button } from '@/components/ui/primitives'
 import { I } from '@/components/icons'
+import { cn } from '@/lib/utils'
 import { fmtDur } from '@/lib/format'
 import { useAudioDevices } from '@/hooks/useAudioDevices'
 import { useWebRTC } from '@/hooks/useWebRTC'
@@ -296,27 +297,10 @@ export function RecordPage() {
   )
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        background: 'var(--bg)',
-      }}
-    >
+    <div className="flex flex-col min-h-screen bg-bg">
       {header}
 
-      <main
-        style={{
-          flex: 1,
-          padding: 24,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 16,
-          width: '100%',
-          boxSizing: 'border-box',
-        }}
-      >
+      <main className="flex-1 p-6 flex flex-col gap-4 w-full box-border">
         {phase === 'idle' ? (
           <IdlePanel
             permission={permission}
@@ -338,19 +322,12 @@ export function RecordPage() {
             />
 
             <div
-              className="rf-record-grid"
-              style={{
-                display: 'grid',
-                // Single pane full-width until translation data lands; then
-                // split into transcript | translation. Keeps the focus on
-                // text you can actually read instead of a half-empty frame.
-                gridTemplateColumns: accumulatedTranslation
-                  ? 'minmax(0, 1fr) minmax(0, 1fr)'
-                  : 'minmax(0, 1fr)',
-                gap: 16,
-                flex: 1,
-                minHeight: 0,
-              }}
+              className={cn(
+                'rf-record-grid grid gap-4 flex-1 min-h-0',
+                accumulatedTranslation
+                  ? 'grid-cols-[minmax(0,1fr)_minmax(0,1fr)]'
+                  : 'grid-cols-[minmax(0,1fr)]',
+              )}
             >
               <AccumulatedPane
                 label="Live transcript"
@@ -399,64 +376,25 @@ function IdlePanel({
     /Chrome|Edg|OPR/.test(navigator.userAgent) &&
     !/Firefox/.test(navigator.userAgent)
   return (
-    <section
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        boxShadow: 'var(--shadow-xs)',
-        padding: 28,
-        maxWidth: 640,
-        margin: '40px auto',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 18,
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
+    <section className="bg-card border border-border rounded-lg shadow-xs p-7 max-w-[640px] mx-auto my-10 flex flex-col gap-[18px] font-sans">
       <header>
-        <h1
-          style={{
-            margin: 0,
-            fontFamily: 'var(--font-serif)',
-            fontSize: 22,
-            fontWeight: 600,
-            letterSpacing: '-0.02em',
-            color: 'var(--fg)',
-          }}
-        >
+        <h1 className="m-0 font-serif text-[22px] font-semibold tracking-[-0.02em] text-fg">
           Ready to record
         </h1>
-        <p
-          style={{
-            margin: '6px 0 0',
-            fontSize: 13,
-            color: 'var(--fg-muted)',
-            lineHeight: 1.5,
-          }}
-        >
+        <p className="mt-1.5 mb-0 text-[13px] text-fg-muted leading-[1.5]">
           Audio streams to the server over WebRTC. Transcription and topics
           appear live while you record.
         </p>
       </header>
 
       {needsPrompt ? (
-        <div
-          style={{
-            padding: 16,
-            background: 'var(--muted)',
-            borderRadius: 'var(--radius-md)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 12,
-          }}
-        >
-          <span style={{ color: 'var(--fg-muted)' }}>{I.Mic(18)}</span>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--fg)' }}>
+        <div className="p-4 bg-muted rounded-md flex items-center gap-3">
+          <span className="text-fg-muted">{I.Mic(18)}</span>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-medium text-fg">
               Microphone access needed
             </div>
-            <div style={{ fontSize: 12, color: 'var(--fg-muted)' }}>
+            <div className="text-xs text-fg-muted">
               {permission === 'denied'
                 ? "You've denied microphone access. Allow it from your browser settings to continue."
                 : 'Grant access to list your input devices.'}
@@ -475,10 +413,9 @@ function IdlePanel({
           </label>
           <select
             id="rf-device"
-            className="rf-select"
+            className="rf-select mt-1.5"
             value={deviceId}
             onChange={(e) => onDeviceId(e.target.value)}
-            style={{ marginTop: 6 }}
           >
             {devices.length === 0 ? (
               <option value="">System default</option>
@@ -493,14 +430,7 @@ function IdlePanel({
         </div>
       )}
 
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          gap: 8,
-          flexWrap: 'wrap',
-        }}
-      >
+      <div className="flex justify-end gap-2 flex-wrap">
         {canShareTabAudio && (
           <Button
             variant="secondary"
@@ -554,35 +484,11 @@ function RecorderStrip({
         : 'var(--status-processing)'
 
   return (
-    <section
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        boxShadow: 'var(--shadow-xs)',
-        padding: 16,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 16,
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 8,
-          fontSize: 12,
-          color: 'var(--fg-muted)',
-          flexShrink: 0,
-          width: 110,
-        }}
-      >
+    <section className="bg-card border border-border rounded-lg shadow-xs p-4 flex items-center gap-4 font-sans">
+      <div className="inline-flex items-center gap-2 text-xs text-fg-muted shrink-0 w-[110px]">
         <span
+          className="w-2 h-2 rounded-full"
           style={{
-            width: 8,
-            height: 8,
-            borderRadius: 999,
             background: statusColor,
             boxShadow: active
               ? `0 0 0 4px color-mix(in srgb, ${statusColor} 25%, transparent)`
@@ -592,20 +498,11 @@ function RecorderStrip({
         {statusLabel}
       </div>
 
-      <div style={{ flex: 1, minWidth: 0 }}>
+      <div className="flex-1 min-w-0">
         <LiveLevelMeter stream={stream} active={active} height={48} />
       </div>
 
-      <div
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 18,
-          color: 'var(--fg)',
-          fontWeight: 600,
-          width: 80,
-          textAlign: 'right',
-        }}
-      >
+      <div className="font-mono text-lg text-fg font-semibold w-20 text-right">
         {fmtDur(elapsed)}
       </div>
     </section>
@@ -631,56 +528,18 @@ function AccumulatedPane({
   }, [text])
 
   return (
-    <section
-      style={{
-        background: 'var(--card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        boxShadow: 'var(--shadow-xs)',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        minHeight: 280,
-      }}
-    >
-      <header
-        style={{
-          padding: '12px 16px',
-          borderBottom: '1px solid var(--border)',
-          fontFamily: 'var(--font-sans)',
-          fontSize: 12,
-          fontWeight: 600,
-          letterSpacing: '0.04em',
-          textTransform: 'uppercase',
-          color: 'var(--fg-muted)',
-        }}
-      >
+    <section className="bg-card border border-border rounded-lg shadow-xs flex flex-col overflow-hidden min-h-[280px]">
+      <header className="py-3 px-4 border-b border-border font-sans text-xs font-semibold tracking-[0.04em] uppercase text-fg-muted">
         {label}
       </header>
       <div
         ref={ref}
-        style={{
-          flex: 1,
-          minHeight: 0,
-          overflowY: 'auto',
-          padding: '16px 18px',
-          fontFamily: 'var(--font-sans)',
-          fontSize: 15,
-          lineHeight: 1.6,
-          color: 'var(--fg)',
-          whiteSpace: 'pre-wrap',
-        }}
+        className="flex-1 min-h-0 overflow-y-auto py-4 px-[18px] font-sans text-[15px] leading-[1.6] text-fg whitespace-pre-wrap"
       >
         {text ? (
           text
         ) : (
-          <div
-            style={{
-              color: 'var(--fg-muted)',
-              fontSize: 13,
-              fontStyle: 'italic',
-            }}
-          >
+          <div className="text-fg-muted text-[13px] italic">
             {placeholder}
           </div>
         )}

--- a/ui/src/pages/RoomPage.tsx
+++ b/ui/src/pages/RoomPage.tsx
@@ -4,6 +4,7 @@ import { WherebyRoom } from '@/components/rooms/WherebyRoom'
 import { LiveKitRoom } from '@/components/rooms/LiveKitRoom'
 import { MeetingSelection } from '@/components/rooms/MeetingSelection'
 import { RoomError, RoomLoading } from '@/components/rooms/roomChrome'
+import { GuestBanner } from '@/components/rooms/GuestBanner'
 import {
   useRoomActiveMeetings,
   useRoomByName,
@@ -89,24 +90,27 @@ export function RoomPage() {
   // ICS room + no explicit id → meeting selection (or auto-route if only one option).
   if (wantSelection) {
     return (
-      <MeetingSelection
-        roomName={roomName}
-        meetings={activeMeetings.data ?? []}
-        loading={activeMeetings.isLoading}
-        creating={createMeeting.isPending}
-        onSelect={(m) => navigate(`/${roomName}/${m.id}`)}
-        onCreateUnscheduled={async () => {
-          try {
-            const m = await createMeeting.mutateAsync({
-              roomName,
-              allowDuplicated: room.ics_enabled ?? false,
-            })
-            navigate(`/${roomName}/${m.id}`)
-          } catch (err) {
-            console.error('Failed to create meeting:', err)
-          }
-        }}
-      />
+      <>
+        <GuestBanner roomName={roomName} />
+        <MeetingSelection
+          roomName={roomName}
+          meetings={activeMeetings.data ?? []}
+          loading={activeMeetings.isLoading}
+          creating={createMeeting.isPending}
+          onSelect={(m) => navigate(`/${roomName}/${m.id}`)}
+          onCreateUnscheduled={async () => {
+            try {
+              const m = await createMeeting.mutateAsync({
+                roomName,
+                allowDuplicated: room.ics_enabled ?? false,
+              })
+              navigate(`/${roomName}/${m.id}`)
+            } catch (err) {
+              console.error('Failed to create meeting:', err)
+            }
+          }}
+        />
+      </>
     )
   }
 
@@ -119,11 +123,26 @@ export function RoomPage() {
   const platform = meeting.platform
   switch (platform) {
     case 'daily':
-      return <DailyRoom roomName={roomName} meeting={meeting} room={room} />
+      return (
+        <>
+          <GuestBanner roomName={roomName} />
+          <DailyRoom roomName={roomName} meeting={meeting} room={room} />
+        </>
+      )
     case 'whereby':
-      return <WherebyRoom roomName={roomName} meeting={meeting} room={room} />
+      return (
+        <>
+          <GuestBanner roomName={roomName} />
+          <WherebyRoom roomName={roomName} meeting={meeting} room={room} />
+        </>
+      )
     case 'livekit':
-      return <LiveKitRoom roomName={roomName} meeting={meeting} room={room} />
+      return (
+        <>
+          <GuestBanner roomName={roomName} />
+          <LiveKitRoom roomName={roomName} meeting={meeting} room={room} />
+        </>
+      )
     default:
       return (
         <RoomError

--- a/ui/src/pages/RoomsPage.tsx
+++ b/ui/src/pages/RoomsPage.tsx
@@ -181,65 +181,23 @@ export function RoomsPage() {
         />
       }
     >
-      <div
-        style={{
-          background: 'var(--card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          overflow: 'hidden',
-          boxShadow: 'var(--shadow-xs)',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 14,
-            padding: '14px 20px',
-            borderBottom: '1px solid var(--border)',
-            background: 'var(--card)',
-            fontFamily: 'var(--font-sans)',
-          }}
-        >
-          <span style={{ color: 'var(--fg)', fontWeight: 600, fontSize: 13 }}>
+      <div className="flex flex-col bg-card border border-border rounded-lg overflow-hidden shadow-xs">
+        <div className="flex items-center gap-3.5 px-5 py-3.5 border-b border-border bg-card font-sans">
+          <span className="text-fg font-semibold text-[13px]">
             {filtered.length} {filtered.length === 1 ? 'room' : 'rooms'}
           </span>
-          <div
-            style={{
-              marginLeft: 4,
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 8,
-              height: 30,
-              padding: '0 10px',
-              background: 'var(--bg)',
-              border: '1px solid var(--border)',
-              borderRadius: 'var(--radius-md)',
-              width: 320,
-              maxWidth: '40%',
-            }}
-          >
-            <span style={{ color: 'var(--fg-muted)', display: 'inline-flex' }}>
+          <div className="ml-1 inline-flex items-center gap-2 h-[30px] px-2.5 bg-bg border border-border rounded-md w-80 max-w-[40%]">
+            <span className="text-fg-muted inline-flex">
               {I.Search(13)}
             </span>
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search rooms, streams, topics…"
-              style={{
-                border: 'none',
-                outline: 'none',
-                background: 'transparent',
-                fontFamily: 'var(--font-sans)',
-                fontSize: 12.5,
-                color: 'var(--fg)',
-                flex: 1,
-              }}
+              className="border-none outline-none bg-transparent font-sans text-[12.5px] text-fg flex-1"
             />
           </div>
-          <div style={{ flex: 1 }} />
+          <div className="flex-1" />
           <Button
             variant="outline"
             size="sm"
@@ -252,46 +210,23 @@ export function RoomsPage() {
           </Button>
         </div>
 
-        <div style={{ overflowY: 'auto' }}>
+        <div className="overflow-y-auto">
           {roomsQuery.isLoading ? (
-            <div style={{ padding: 32, textAlign: 'center', color: 'var(--fg-muted)' }}>
+            <div className="p-8 text-center text-fg-muted">
               Loading…
             </div>
           ) : filtered.length === 0 ? (
-            <div
-              style={{
-                padding: '80px 24px',
-                textAlign: 'center',
-                color: 'var(--fg-muted)',
-                fontFamily: 'var(--font-sans)',
-              }}
-            >
+            <div className="px-6 py-20 text-center text-fg-muted font-sans">
               <div
-                style={{
-                  width: 48,
-                  height: 48,
-                  borderRadius: 9999,
-                  background: 'var(--muted)',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  color: 'var(--gh-grey-4)',
-                  marginBottom: 12,
-                }}
+                className="w-12 h-12 rounded-full bg-muted inline-flex items-center justify-center mb-3"
+                style={{ color: 'var(--gh-grey-4)' }}
               >
                 {I.Door(22)}
               </div>
-              <div
-                style={{
-                  fontFamily: 'var(--font-serif)',
-                  fontSize: 18,
-                  fontWeight: 600,
-                  color: 'var(--fg)',
-                }}
-              >
+              <div className="font-serif text-lg font-semibold text-fg">
                 {search ? `No rooms match “${search}”` : 'No rooms match this filter'}
               </div>
-              <div style={{ fontSize: 13, maxWidth: 360, margin: '8px auto 0' }}>
+              <div className="text-[13px] max-w-[360px] mx-auto mt-2">
                 {search
                   ? 'Try a different term, or clear the search.'
                   : 'Clear the sidebar filter, or create a new room to get started.'}
@@ -370,33 +305,11 @@ function Section({
 }) {
   return (
     <div>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'baseline',
-          gap: 10,
-          padding: '18px 20px 10px',
-          fontFamily: 'var(--font-sans)',
-        }}
-      >
-        <span
-          style={{
-            fontFamily: 'var(--font-serif)',
-            fontSize: 15,
-            fontWeight: 600,
-            color: 'var(--fg)',
-            letterSpacing: '-0.005em',
-          }}
-        >
+      <div className="flex items-baseline gap-2.5 px-5 pt-[18px] pb-2.5 font-sans">
+        <span className="font-serif text-[15px] font-semibold text-fg tracking-[-0.005em]">
           {label}
         </span>
-        <span
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 11,
-            color: 'var(--fg-muted)',
-          }}
-        >
+        <span className="font-mono text-[11px] text-fg-muted">
           {count} {count === 1 ? 'room' : 'rooms'}
         </span>
       </div>

--- a/ui/src/pages/TranscriptPage.tsx
+++ b/ui/src/pages/TranscriptPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/transcript/Banners'
 import { AudioPlayer } from '@/components/transcript/AudioPlayer'
 import { TopicsList } from '@/components/transcript/TopicsList'
-import { SummaryPanel } from '@/components/transcript/SummaryPanel'
+import { SummaryTranslationTabs } from '@/components/transcript/SummaryTranslationTabs'
 import { VideoPanel } from '@/components/transcript/VideoPanel'
 import { ShareDialog } from '@/components/transcript/ShareDialog'
 import { useAuth } from '@/auth/AuthContext'
@@ -208,14 +208,7 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
 
   if (transcriptQuery.isLoading) {
     return renderShell(
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-sans)',
-        }}
-      >
+      <div className="p-10 text-center text-fg-muted font-sans">
         Loading transcript…
       </div>,
       'Transcript',
@@ -227,14 +220,7 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
     const status404 = errStatus === 404
     const status403 = errStatus === 403 || errStatus === 401
     return renderShell(
-      <div
-        style={{
-          padding: 40,
-          textAlign: 'center',
-          color: 'var(--fg-muted)',
-          fontFamily: 'var(--font-sans)',
-        }}
-      >
+      <div className="p-10 text-center text-fg-muted font-sans">
         {status403
           ? "This transcript isn't available."
           : status404
@@ -254,22 +240,8 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
 
   const body = (
     <>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 16,
-        }}
-      >
-        <div
-          style={{
-            background: 'var(--card)',
-            border: '1px solid var(--border)',
-            borderRadius: 'var(--radius-lg)',
-            boxShadow: 'var(--shadow-xs)',
-            overflow: 'hidden',
-          }}
-        >
+      <div className="flex flex-col gap-4">
+        <div className="bg-card border border-border rounded-lg shadow-xs overflow-hidden">
           <TranscriptHeader
             transcript={transcript}
             canEdit={canEdit}
@@ -285,7 +257,7 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
             videoOpen={videoOpen}
             readOnly={anonymous}
           />
-          <div style={{ padding: '12px 20px 16px' }}>
+          <div className="px-5 pt-3 pb-4">
             <MetadataStrip transcript={transcript} speakerCount={speakerCount} />
           </div>
         </div>
@@ -315,31 +287,12 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
             ) : null}
 
             <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr)',
-                gap: 16,
-              }}
-              className="rf-detail-grid"
+              className="grid gap-4 rf-detail-grid"
+              style={{ gridTemplateColumns: 'minmax(0, 1.6fr) minmax(0, 1fr)' }}
             >
-              <div
-                style={{
-                  background: 'var(--card)',
-                  border: '1px solid var(--border)',
-                  borderRadius: 'var(--radius-lg)',
-                  boxShadow: 'var(--shadow-xs)',
-                  overflow: 'hidden',
-                }}
-              >
+              <div className="bg-card border border-border rounded-lg shadow-xs overflow-hidden">
                 {topicsQuery.isLoading ? (
-                  <div
-                    style={{
-                      padding: 40,
-                      textAlign: 'center',
-                      color: 'var(--fg-muted)',
-                      fontFamily: 'var(--font-sans)',
-                    }}
-                  >
+                  <div className="p-10 text-center text-fg-muted font-sans">
                     Loading topics…
                   </div>
                 ) : (
@@ -353,11 +306,16 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
                 )}
               </div>
 
-              <SummaryPanel
+              <SummaryTranslationTabs
                 summary={transcript.long_summary}
+                topics={topics}
+                participants={participants}
+                sourceLanguage={transcript.source_language}
+                targetLanguage={transcript.target_language}
                 canEdit={canEdit}
                 saving={update.isPending}
-                onSave={handleSummarySave}
+                onSaveSummary={handleSummarySave}
+                onSeek={seekTo}
               />
             </div>
           </>
@@ -394,7 +352,7 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
           title="Move to trash?"
           message={
             <>
-              <strong style={{ color: 'var(--fg)' }}>
+              <strong className="text-fg">
                 {transcript.title?.trim() || 'Untitled transcript'}
               </strong>{' '}
               will be moved to the trash. You can restore it later.
@@ -419,14 +377,7 @@ export function TranscriptPage({ anonymous = false }: TranscriptPageProps = {}) 
 function Navigate() {
   // Defensive: route guard hits this when :id is missing.
   return (
-    <div
-      style={{
-        padding: 40,
-        textAlign: 'center',
-        color: 'var(--fg-muted)',
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
+    <div className="p-10 text-center text-fg-muted font-sans">
       Missing transcript id.
     </div>
   )

--- a/ui/src/pages/UploadPage.tsx
+++ b/ui/src/pages/UploadPage.tsx
@@ -5,6 +5,7 @@ import { AppShell } from '@/components/layout/AppShell'
 import { AppSidebar } from '@/components/layout/AppSidebar'
 import { I } from '@/components/icons'
 import { Button } from '@/components/ui/primitives'
+import { cn } from '@/lib/utils'
 import { getPasswordToken } from '@/api/client'
 import { useRooms } from '@/hooks/useRooms'
 import { useTranscript, useTranscriptMutations } from '@/hooks/useTranscript'
@@ -137,40 +138,12 @@ export function UploadPage() {
         />
       }
     >
-      <div
-        style={{
-          background: 'var(--card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          boxShadow: 'var(--shadow-xs)',
-          padding: 24,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 16,
-        }}
-      >
+      <div className="bg-card border border-border rounded-lg shadow-xs p-6 flex flex-col gap-4">
         <div>
-          <h1
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-serif)',
-              fontSize: 22,
-              fontWeight: 600,
-              letterSpacing: '-0.02em',
-              color: 'var(--fg)',
-            }}
-          >
+          <h1 className="m-0 font-serif text-[22px] font-semibold tracking-[-0.02em] text-fg">
             Upload a recording
           </h1>
-          <p
-            style={{
-              margin: '4px 0 0',
-              fontSize: 13,
-              color: 'var(--fg-muted)',
-              fontFamily: 'var(--font-sans)',
-              lineHeight: 1.5,
-            }}
-          >
+          <p className="mt-1 mb-0 text-[13px] text-fg-muted font-sans leading-[1.5]">
             Drop an audio or video file. Large files are split into 50 MB chunks
             and resumed on error.
           </p>
@@ -190,19 +163,13 @@ export function UploadPage() {
             if (f) pickFile(f)
           }}
           htmlFor="rf-upload-input"
-          style={{
-            display: 'block',
-            border: `2px dashed ${dragOver ? 'var(--primary)' : 'var(--border)'}`,
-            background: dragOver
-              ? 'color-mix(in srgb, var(--primary) 6%, var(--card))'
-              : 'var(--card)',
-            borderRadius: 'var(--radius-md)',
-            padding: 32,
-            textAlign: 'center',
-            cursor: uploading ? 'not-allowed' : 'pointer',
-            fontFamily: 'var(--font-sans)',
-            transition: 'background var(--dur-fast), border-color var(--dur-fast)',
-          }}
+          className={cn(
+            'block border-2 border-dashed rounded-md p-8 text-center font-sans transition-[background,border-color] duration-[var(--dur-fast)]',
+            dragOver
+              ? 'border-primary bg-[color-mix(in_srgb,var(--primary)_6%,var(--card))]'
+              : 'border-border bg-card',
+            uploading ? 'cursor-not-allowed' : 'cursor-pointer',
+          )}
         >
           <input
             ref={inputRef}
@@ -216,59 +183,26 @@ export function UploadPage() {
               // allow picking the same file again
               e.target.value = ''
             }}
-            style={{ display: 'none' }}
+            className="hidden"
           />
-          <div
-            style={{
-              display: 'inline-flex',
-              color: 'var(--fg-muted)',
-              marginBottom: 10,
-            }}
-          >
+          <div className="inline-flex text-fg-muted mb-2.5">
             {I.Upload(26)}
           </div>
           {file ? (
             <div>
-              <div
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 12.5,
-                  color: 'var(--fg)',
-                  fontWeight: 500,
-                  wordBreak: 'break-all',
-                }}
-              >
+              <div className="font-mono text-[12.5px] text-fg font-medium break-all">
                 {file.name}
               </div>
-              <div
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 11.5,
-                  color: 'var(--fg-muted)',
-                  marginTop: 2,
-                }}
-              >
+              <div className="font-mono text-[11.5px] text-fg-muted mt-0.5">
                 {readableSize(file.size)}
               </div>
             </div>
           ) : (
             <>
-              <div
-                style={{
-                  fontSize: 14,
-                  fontWeight: 500,
-                  color: 'var(--fg)',
-                }}
-              >
+              <div className="text-sm font-medium text-fg">
                 Drag and drop a file here
               </div>
-              <div
-                style={{
-                  marginTop: 4,
-                  fontSize: 12,
-                  color: 'var(--fg-muted)',
-                }}
-              >
+              <div className="mt-1 text-xs text-fg-muted">
                 or click to pick one. Supports mp3, m4a, wav, mp4, mov, webm.
               </div>
             </>
@@ -276,40 +210,15 @@ export function UploadPage() {
         </label>
 
         {uploading && (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 6,
-              fontFamily: 'var(--font-sans)',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                fontSize: 12,
-                color: 'var(--fg-muted)',
-              }}
-            >
+          <div className="flex flex-col gap-1.5 font-sans">
+            <div className="flex justify-between text-xs text-fg-muted">
               <span>Uploading…</span>
-              <span style={{ fontFamily: 'var(--font-mono)' }}>{progress}%</span>
+              <span className="font-mono">{progress}%</span>
             </div>
-            <div
-              style={{
-                height: 6,
-                background: 'var(--muted)',
-                borderRadius: 999,
-                overflow: 'hidden',
-              }}
-            >
+            <div className="h-1.5 bg-muted rounded-full overflow-hidden">
               <div
-                style={{
-                  width: `${progress}%`,
-                  height: '100%',
-                  background: 'var(--primary)',
-                  transition: 'width var(--dur-fast) var(--ease-default)',
-                }}
+                className="h-full bg-primary transition-[width] duration-[var(--dur-fast)] ease-[var(--ease-default)]"
+                style={{ width: `${progress}%` }}
               />
             </div>
           </div>
@@ -318,27 +227,13 @@ export function UploadPage() {
         {error && (
           <div
             role="alert"
-            style={{
-              padding: '10px 12px',
-              borderRadius: 'var(--radius-md)',
-              background: 'color-mix(in srgb, var(--destructive) 8%, transparent)',
-              border: '1px solid color-mix(in srgb, var(--destructive) 25%, transparent)',
-              color: 'var(--destructive)',
-              fontFamily: 'var(--font-sans)',
-              fontSize: 13,
-            }}
+            className="py-2.5 px-3 rounded-md bg-[color-mix(in_srgb,var(--destructive)_8%,transparent)] border border-[color-mix(in_srgb,var(--destructive)_25%,transparent)] text-destructive font-sans text-[13px]"
           >
             {error}
           </div>
         )}
 
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: 8,
-          }}
-        >
+        <div className="flex justify-end gap-2">
           <Button
             variant="ghost"
             size="md"

--- a/ui/src/styles/index.css
+++ b/ui/src/styles/index.css
@@ -26,6 +26,13 @@
   --color-input: var(--input);
   --color-ring: var(--ring);
 
+  /* Status palette — exposed as `bg-status-live`, `text-status-processing`, etc. */
+  --color-status-live: var(--status-live);
+  --color-status-ok: var(--status-ok);
+  --color-status-processing: var(--status-processing);
+  --color-status-failed: var(--status-failed);
+  --color-status-idle: var(--status-idle);
+
   --font-sans: var(--font-sans);
   --font-serif: var(--font-serif);
   --font-mono: var(--font-mono);
@@ -34,6 +41,13 @@
   --radius-md: var(--radius-md);
   --radius-lg: var(--radius-lg);
   --radius-xl: var(--radius-xl);
+
+  /* Greyhaven shadow scale — replaces Tailwind defaults so `shadow-xs|sm|md|lg`
+     resolve to the design-system values defined in greyhaven.css. */
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
 }
 
 /* Reflector sub-brand accent — orange. Sits on top of Greyhaven semantics so


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This pr includes changes planned in 
[uiv2-followups.md](https://github.com/user-attachments/files/28519700/uiv2-followups.md)

These items are not going to be implemented in this iteration
**5,6, 11,13,14,15,17,19,17.b, 18.b** 

These items can't ve complete due a missing context or need more details of the change 

**2.** Enhanced processing view
**8.** Service-worker audio streaming

worked items 

**1. Speaker correction,** there are some old code in the www/ path but not functional, so not moved to UI 
```
 www/app/(app)/transcripts/[transcriptId]/correct/
  ├── page.tsx              (133 LOC — route entry)
  ├── participantList.tsx   (503 LOC — speaker rename/merge sidebar)
  ├── topicWords.tsx        (220 LOC — word-level editor with selection state)
  ├── topicPlayer.tsx       (253 LOC — audio scrubber for the active topic)
  ├── topicHeader.tsx       (153 LOC — topic-nav bar)
  ├── soundWaveCss.tsx      (29 LOC — waveform styling)
  └── types.ts              (20 LOC)

 - GET /v1/transcripts/{id}/topics/{topic_id}/words-per-speaker
  - POST /v1/transcripts/{id}/speaker/assign
  - POST /v1/transcripts/{id}/speaker/merge
  - POST /v1/transcripts/{id}/participants/{participant_id}  
```

**3. Public room access on `/v2`**
<img width="1305" height="738" alt="image" src="https://github.com/user-attachments/assets/5425097a-63d3-40e1-aecd-eda27e852474" />

**4. LiveKit in-app SDK** already done, any changes here, the actual implementation in ui/src/components/rooms/LiveKitRoom.tsx uses the native LiveKit React SDK

**7. Tailwind migration** -Done

**9. Reprocess action**
<img width="585" height="318" alt="image" src="https://github.com/user-attachments/assets/b7c32aa4-4ab5-4d21-8015-3927f4281240" />

**10. Translation viewing**

<img width="381" height="444" alt="image" src="https://github.com/user-attachments/assets/2e7dba4a-b4cb-4ab6-99c0-e3d4c020515e" />


**12. Auto-detect language in `CreateTranscript`**  and 
**20. Translation in transcript detail** 
<img width="558" height="448" alt="image" src="https://github.com/user-attachments/assets/db817458-eb71-4652-a583-6845b084c215" />

**16. Share-dialog error-boundary fallback URL**
<img width="725" height="403" alt="image" src="https://github.com/user-attachments/assets/525b24d9-40e8-40da-99f6-5db83dbd401d" />




## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
