### PR TITLE
feat: tag outbound LLM calls with app and context attribution

### DIFF
--- a/.github/workflows/dockerhub-backend.yml
+++ b/.github/workflows/dockerhub-backend.yml
@@ -48,6 +48,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REFLECTOR_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/docsv2/selfhosted-production.md
+++ b/docsv2/selfhosted-production.md
@@ -259,6 +259,7 @@ To change the configuration, pass new flags — they override and replace the sa
 | `LLM_URL` | OpenAI-compatible LLM endpoint | Auto-set for Ollama modes |
 | `LLM_API_KEY` | LLM API key | `not-needed` for Ollama |
 | `LLM_MODEL` | LLM model name | `qwen2.5:14b` for Ollama (override with `--llm-model`) |
+| `REFLECTOR_VERSION` | Version reported in the `User-Agent` of outbound LLM calls | `dev` (set at image build time for released images) |
 | `CELERY_BEAT_POLL_INTERVAL` | Override all worker polling intervals (seconds). `0` = use individual defaults | `300` (selfhosted), `0` (other) |
 | `TRANSCRIPT_STORAGE_BACKEND` | Storage backend | `aws` |
 | `TRANSCRIPT_STORAGE_AWS_*` | S3 credentials | Auto-set for Garage |

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -37,4 +37,9 @@ RUN uv run python -c "import silero_vad.model"
 
 RUN chmod +x /app/docker-entrypoint.sh
 
+# Version reported in the User-Agent of outbound LLM calls.
+# Late in the file so a version bump does not invalidate the layer cache.
+ARG REFLECTOR_VERSION=dev
+ENV REFLECTOR_VERSION=${REFLECTOR_VERSION}
+
 CMD ["./docker-entrypoint.sh"]

--- a/server/reflector/hatchet/workflows/daily_multitrack_pipeline.py
+++ b/server/reflector/hatchet/workflows/daily_multitrack_pipeline.py
@@ -1098,7 +1098,7 @@ async def extract_subjects(input: PipelineInput, ctx: Context) -> SubjectsResult
             }
 
         # TODO: refactor SummaryBuilder methods into standalone functions
-        llm = LLM(settings=settings)
+        llm = LLM(settings=settings, context="summary")
         builder = SummaryBuilder(llm, logger=logger)
         builder.set_transcript(transcript_text)
 
@@ -1218,7 +1218,7 @@ async def generate_recap(input: PipelineInput, ctx: Context) -> RecapResult:
 
     summaries_text = "\n\n".join([f"{s['subject']}: {s['summary']}" for s in summaries])
 
-    llm = LLM(settings=settings)
+    llm = LLM(settings=settings, context="summary")
 
     participant_instructions = build_participant_instructions(
         subjects_result.participant_names
@@ -1300,7 +1300,7 @@ async def identify_action_items(
     )
 
     # TODO: refactor SummaryBuilder methods into standalone functions
-    llm = LLM(settings=settings)
+    llm = LLM(settings=settings, context="summary")
     builder = SummaryBuilder(llm, logger=logger)
     builder.set_transcript(subjects_result.transcript_text)
 

--- a/server/reflector/hatchet/workflows/subject_processing.py
+++ b/server/reflector/hatchet/workflows/subject_processing.py
@@ -62,7 +62,7 @@ async def generate_detailed_summary(
         subject_index=input.subject_index,
     )
 
-    llm = LLM(settings=settings)
+    llm = LLM(settings=settings, context="summary")
 
     participant_instructions = build_participant_instructions(input.participant_names)
     detailed_prompt = DETAILED_SUBJECT_PROMPT_TEMPLATE.format(subject=input.subject)

--- a/server/reflector/hatchet/workflows/topic_chunk_processing.py
+++ b/server/reflector/hatchet/workflows/topic_chunk_processing.py
@@ -68,7 +68,7 @@ async def detect_chunk_topic(input: TopicChunkInput, ctx: Context) -> TopicChunk
         text_length=len(input.chunk_text),
     )
 
-    llm = LLM(settings=settings, temperature=0.9)
+    llm = LLM(settings=settings, temperature=0.9, context="topic")
 
     prompt = TOPIC_PROMPT.format(text=input.chunk_text)
     response = await llm.get_structured_response(

--- a/server/reflector/llm.py
+++ b/server/reflector/llm.py
@@ -1,6 +1,6 @@
 import logging
 from contextvars import ContextVar
-from typing import Type, TypeVar
+from typing import Literal, Type, TypeVar
 from uuid import uuid4
 
 from llama_index.core import Settings
@@ -18,6 +18,20 @@ llm_session_id: ContextVar[str | None] = ContextVar("llm_session_id", default=No
 
 logger = logging.getLogger(__name__)
 
+# Attribution sent to the LLM gateway so spend can be split per app and per
+# part of the app. Contexts are coarse on purpose: one LLM instance always
+# serves exactly one context, so the headers can be baked into the client.
+LLM_APP = "reflector"
+LLMContext = Literal["topic", "title", "summary"]
+
+
+def build_llm_headers(context: LLMContext, version: str) -> dict[str, str]:
+    """Build the attribution headers for outbound LLM requests."""
+    return {
+        "User-Agent": f"{LLM_APP}/{version}",
+        "x-llmproxy-tags": f"app:{LLM_APP},context:{context}",
+    }
+
 
 class LLMParseError(Exception):
     """Raised when LLM output cannot be parsed after retries."""
@@ -33,7 +47,12 @@ class LLMParseError(Exception):
 
 class LLM:
     def __init__(
-        self, settings, temperature: float = 0.4, max_tokens: int | None = None
+        self,
+        settings,
+        temperature: float = 0.4,
+        max_tokens: int | None = None,
+        *,
+        context: LLMContext,
     ):
         self.settings_obj = settings
         self.model_name = settings.LLM_MODEL
@@ -42,14 +61,21 @@ class LLM:
         self.context_window = settings.LLM_CONTEXT_WINDOW
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.context = context
 
         self._configure_llamaindex()
 
     def _configure_llamaindex(self):
-        """Configure llamaindex Settings with OpenAILike LLM"""
+        """Build the OpenAILike client for this instance.
+
+        The client is kept on the instance and used directly by both entry
+        points. Assigning only the llamaindex process global would let the
+        last constructed LLM win for every concurrent instance, which would
+        send the wrong temperature, session id and attribution context.
+        """
         session_id = llm_session_id.get() or f"fallback-{uuid4().hex}"
 
-        Settings.llm = OpenAILike(
+        self._llm = OpenAILike(
             model=self.model_name,
             api_base=self.url,
             api_key=self.api_key,
@@ -60,7 +86,13 @@ class LLM:
             max_tokens=self.max_tokens,
             timeout=self.settings_obj.LLM_REQUEST_TIMEOUT,
             additional_kwargs={"extra_body": {"litellm_session_id": session_id}},
+            default_headers=build_llm_headers(
+                self.context, self.settings_obj.REFLECTOR_VERSION
+            ),
         )
+
+        # Kept for anything still reading the llamaindex global.
+        Settings.llm = self._llm
 
     async def get_response(
         self, prompt: str, texts: list[str], tone_name: str | None = None
@@ -72,7 +104,7 @@ class LLM:
         """
 
         async def _call():
-            summarizer = TreeSummarize(verbose=False)
+            summarizer = TreeSummarize(llm=self._llm, verbose=False)
             response = await summarizer.aget_response(
                 prompt, texts, tone_name=tone_name
             )
@@ -119,14 +151,14 @@ class LLM:
             for attempt in range(1, max_retries + 2):  # +2: first try + retries
                 try:
                     if attempt == 1:
-                        result = await Settings.llm.astructured_predict(
+                        result = await self._llm.astructured_predict(
                             output_cls, prompt_tmpl, user_prompt=full_prompt
                         )
                     else:
                         reflection_tmpl = PromptTemplate(
                             "{user_prompt}\n\n{reflection}"
                         )
-                        result = await Settings.llm.astructured_predict(
+                        result = await self._llm.astructured_predict(
                             output_cls,
                             reflection_tmpl,
                             user_prompt=full_prompt,

--- a/server/reflector/processors/summary/summary_builder.py
+++ b/server/reflector/processors/summary/summary_builder.py
@@ -577,7 +577,7 @@ if __name__ == "__main__":
     async def main():
         # build the summary
 
-        llm = LLM(settings=settings)
+        llm = LLM(settings=settings, context="summary")
         sm = SummaryBuilder(llm=llm, filename=args.transcript)
 
         if args.subjects:

--- a/server/reflector/processors/transcript_final_summary.py
+++ b/server/reflector/processors/transcript_final_summary.py
@@ -22,7 +22,7 @@ class TranscriptFinalSummaryProcessor(Processor):
         super().__init__(**kwargs)
         self.transcript = transcript
         self.chunks: list[TitleSummary] = []
-        self.llm = LLM(settings=settings)
+        self.llm = LLM(settings=settings, context="summary")
         self.builder = None
 
     async def _push(self, data: TitleSummary):

--- a/server/reflector/processors/transcript_final_title.py
+++ b/server/reflector/processors/transcript_final_title.py
@@ -39,7 +39,7 @@ class TranscriptFinalTitleProcessor(Processor):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.chunks: list[TitleSummary] = []
-        self.llm = LLM(settings=settings, temperature=0.5)
+        self.llm = LLM(settings=settings, temperature=0.5, context="title")
 
     async def _push(self, data: TitleSummary):
         self.chunks.append(data)

--- a/server/reflector/processors/transcript_topic_detector.py
+++ b/server/reflector/processors/transcript_topic_detector.py
@@ -37,7 +37,7 @@ class TranscriptTopicDetectorProcessor(Processor):
         super().__init__(**kwargs)
         self.transcript = None
         self.min_transcript_length = min_transcript_length
-        self.llm = LLM(settings=settings, temperature=0.9)
+        self.llm = LLM(settings=settings, temperature=0.9, context="topic")
 
     async def _push(self, data: Transcript):
         if self.transcript is None:

--- a/server/reflector/settings.py
+++ b/server/reflector/settings.py
@@ -109,6 +109,10 @@ class Settings(BaseSettings):
         300  # Timeout in seconds for structured responses (5 minutes)
     )
 
+    # Version reported in the User-Agent of outbound LLM calls.
+    # Injected at image build time; "dev" for local runs.
+    REFLECTOR_VERSION: str = "dev"
+
     # Diarization
     # backends: modal — HTTP API client, pyannote — in-process pyannote.audio
     DIARIZATION_ENABLED: bool = True

--- a/server/tests/test_llm_headers.py
+++ b/server/tests/test_llm_headers.py
@@ -1,0 +1,71 @@
+"""Tests for LLM attribution headers (User-Agent and x-llmproxy-tags)"""
+
+import pytest
+
+from reflector.llm import LLM, build_llm_headers
+
+
+class TestBuildLLMHeaders:
+    """Test the header builder in isolation"""
+
+    def test_headers_exact_values(self):
+        headers = build_llm_headers("summary", "0.45.0")
+
+        assert headers == {
+            "User-Agent": "reflector/0.45.0",
+            "x-llmproxy-tags": "app:reflector,context:summary",
+        }
+
+    @pytest.mark.parametrize("context", ["topic", "title", "summary"])
+    def test_context_appears_in_tags(self, context):
+        headers = build_llm_headers(context, "dev")
+
+        assert headers["x-llmproxy-tags"] == f"app:reflector,context:{context}"
+        assert headers["User-Agent"] == "reflector/dev"
+
+
+class TestLLMInstanceHeaders:
+    """Test that constructed LLM instances carry the headers"""
+
+    def test_instance_client_has_headers(self, test_settings):
+        llm = LLM(settings=test_settings, context="title")
+
+        assert llm._llm.default_headers == {
+            "User-Agent": "reflector/dev",
+            "x-llmproxy-tags": "app:reflector,context:title",
+        }
+
+    def test_version_flows_from_settings(self, test_settings):
+        test_settings.REFLECTOR_VERSION = "1.2.3"
+
+        llm = LLM(settings=test_settings, context="topic")
+
+        assert llm._llm.default_headers["User-Agent"] == "reflector/1.2.3"
+
+    def test_context_is_required(self, test_settings):
+        with pytest.raises(TypeError):
+            LLM(settings=test_settings)
+
+    def test_headers_reach_the_http_client(self, test_settings):
+        """default_headers must be applied to the underlying OpenAI SDK client,
+        not just stored on the llama-index wrapper."""
+        llm = LLM(settings=test_settings, context="summary")
+
+        client_headers = llm._llm._get_client().default_headers
+
+        assert client_headers["User-Agent"] == "reflector/dev"
+        assert client_headers["x-llmproxy-tags"] == "app:reflector,context:summary"
+
+    def test_instances_do_not_leak_context_to_each_other(self, test_settings):
+        """Two concurrent LLM instances must keep their own headers."""
+        title_llm = LLM(settings=test_settings, context="title")
+        summary_llm = LLM(settings=test_settings, context="summary")
+
+        assert (
+            title_llm._llm.default_headers["x-llmproxy-tags"]
+            == "app:reflector,context:title"
+        )
+        assert (
+            summary_llm._llm.default_headers["x-llmproxy-tags"]
+            == "app:reflector,context:summary"
+        )

--- a/server/tests/test_llm_retry.py
+++ b/server/tests/test_llm_retry.py
@@ -23,7 +23,9 @@ class TestLLMParseErrorRecovery:
     @pytest.mark.asyncio
     async def test_parse_error_recovery_with_feedback(self, test_settings):
         """Test that parse errors trigger retry with reflection prompt"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         call_count = {"count": 0}
 
@@ -49,8 +51,8 @@ class TestLLMParseErrorRecovery:
                 assert "Error:" in kwargs["reflection"]
                 return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=astructured_predict_handler
             )
 
@@ -66,7 +68,9 @@ class TestLLMParseErrorRecovery:
     @pytest.mark.asyncio
     async def test_max_parse_retry_attempts(self, test_settings):
         """Test that parse error retry stops after max attempts"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         # Always raise ValidationError
         async def always_fail(output_cls, prompt_tmpl, **kwargs):
@@ -82,8 +86,8 @@ class TestLLMParseErrorRecovery:
                 ],
             )
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(side_effect=always_fail)
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(side_effect=always_fail)
 
             with pytest.raises(LLMParseError, match="Failed to parse"):
                 await llm.get_structured_response(
@@ -91,12 +95,14 @@ class TestLLMParseErrorRecovery:
                 )
 
             expected_attempts = test_settings.LLM_PARSE_MAX_RETRIES + 1
-            assert mock_settings.llm.astructured_predict.call_count == expected_attempts
+            assert mock_llm.astructured_predict.call_count == expected_attempts
 
     @pytest.mark.asyncio
     async def test_raw_response_logging_on_parse_error(self, test_settings, caplog):
         """Test that raw response is logged when parse error occurs"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         call_count = {"count": 0}
 
@@ -117,10 +123,10 @@ class TestLLMParseErrorRecovery:
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
         with (
-            patch("reflector.llm.Settings") as mock_settings,
+            patch.object(llm, "_llm") as mock_llm,
             caplog.at_level("ERROR"),
         ):
-            mock_settings.llm.astructured_predict = AsyncMock(
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=astructured_predict_handler
             )
 
@@ -137,7 +143,9 @@ class TestLLMParseErrorRecovery:
     @pytest.mark.asyncio
     async def test_multiple_validation_errors_in_feedback(self, test_settings):
         """Test that validation errors are included in reflection feedback"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         call_count = {"count": 0}
 
@@ -171,8 +179,8 @@ class TestLLMParseErrorRecovery:
                 )
                 return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=astructured_predict_handler
             )
 
@@ -186,10 +194,12 @@ class TestLLMParseErrorRecovery:
     @pytest.mark.asyncio
     async def test_success_on_first_attempt(self, test_settings):
         """Test that no retry happens when first attempt succeeds"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 return_value=TestResponse(
                     title="Test", summary="Summary", confidence=0.95
                 )
@@ -202,7 +212,7 @@ class TestLLMParseErrorRecovery:
             assert result.title == "Test"
             assert result.summary == "Summary"
             assert result.confidence == 0.95
-            assert mock_settings.llm.astructured_predict.call_count == 1
+            assert mock_llm.astructured_predict.call_count == 1
 
 
 class TestNetworkErrorRetries:
@@ -211,7 +221,9 @@ class TestNetworkErrorRetries:
     @pytest.mark.asyncio
     async def test_network_error_retried_by_outer_wrapper(self, test_settings):
         """Test that network errors trigger the outer retry wrapper"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         call_count = {"count": 0}
 
@@ -221,8 +233,8 @@ class TestNetworkErrorRetries:
                 raise ConnectionError("Connection refused")
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=astructured_predict_handler
             )
 
@@ -236,10 +248,12 @@ class TestNetworkErrorRetries:
     @pytest.mark.asyncio
     async def test_network_error_exhausts_retries(self, test_settings):
         """Test that persistent network errors exhaust retry attempts"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=ConnectionError("Connection refused")
             )
 
@@ -249,7 +263,7 @@ class TestNetworkErrorRetries:
                 )
 
             # 3 retry attempts
-            assert mock_settings.llm.astructured_predict.call_count == 3
+            assert mock_llm.astructured_predict.call_count == 3
 
 
 class TestGetResponseRetries:
@@ -258,7 +272,9 @@ class TestGetResponseRetries:
     @pytest.mark.asyncio
     async def test_get_response_retries_on_connection_error(self, test_settings):
         """Test that get_response retries on ConnectionError and returns on success."""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         mock_instance = MagicMock()
         mock_instance.aget_response = AsyncMock(
@@ -277,7 +293,9 @@ class TestGetResponseRetries:
     @pytest.mark.asyncio
     async def test_get_response_exhausts_retries(self, test_settings):
         """Test that get_response raises RetryException after retry attempts exceeded."""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         mock_instance = MagicMock()
         mock_instance.aget_response = AsyncMock(
@@ -297,7 +315,9 @@ class TestGetResponseRetries:
         retry() must return falsy results (e.g. '' from get_response) instead of
         treating them as 'no result' and retrying until RetryException.
         """
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         mock_instance = MagicMock()
         mock_instance.aget_response = AsyncMock(return_value="   \n  ")  # strip() -> ""
@@ -315,7 +335,9 @@ class TestTextsInclusion:
     @pytest.mark.asyncio
     async def test_texts_included_in_prompt(self, test_settings):
         """Test that texts content is appended to the prompt for astructured_predict"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         captured_prompts = []
 
@@ -323,10 +345,8 @@ class TestTextsInclusion:
             captured_prompts.append(kwargs.get("user_prompt", ""))
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
-                side_effect=capture_prompt
-            )
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(side_effect=capture_prompt)
 
             await llm.get_structured_response(
                 prompt="Identify all participants",
@@ -343,7 +363,9 @@ class TestTextsInclusion:
     @pytest.mark.asyncio
     async def test_empty_texts_uses_prompt_only(self, test_settings):
         """Test that empty texts list sends only the prompt"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         captured_prompts = []
 
@@ -351,10 +373,8 @@ class TestTextsInclusion:
             captured_prompts.append(kwargs.get("user_prompt", ""))
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
-                side_effect=capture_prompt
-            )
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(side_effect=capture_prompt)
 
             await llm.get_structured_response(
                 prompt="Identify all participants",
@@ -368,7 +388,9 @@ class TestTextsInclusion:
     @pytest.mark.asyncio
     async def test_texts_included_in_reflection_retry(self, test_settings):
         """Test that texts are included in the prompt even during reflection retries"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         captured_prompts = []
         call_count = {"count": 0}
@@ -390,10 +412,8 @@ class TestTextsInclusion:
                 )
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
-                side_effect=capture_and_fail_first
-            )
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(side_effect=capture_and_fail_first)
 
             await llm.get_structured_response(
                 prompt="Summarize this",
@@ -414,7 +434,9 @@ class TestReflectionRetryBackoff:
     @pytest.mark.asyncio
     async def test_value_error_triggers_reflection(self, test_settings):
         """Test that ValueError (parse failure) also triggers reflection retry"""
-        llm = LLM(settings=test_settings, temperature=0.4, max_tokens=100)
+        llm = LLM(
+            settings=test_settings, temperature=0.4, max_tokens=100, context="summary"
+        )
 
         call_count = {"count": 0}
 
@@ -425,8 +447,8 @@ class TestReflectionRetryBackoff:
             assert "reflection" in kwargs
             return TestResponse(title="Test", summary="Summary", confidence=0.95)
 
-        with patch("reflector.llm.Settings") as mock_settings:
-            mock_settings.llm.astructured_predict = AsyncMock(
+        with patch.object(llm, "_llm") as mock_llm:
+            mock_llm.astructured_predict = AsyncMock(
                 side_effect=astructured_predict_handler
             )
 


### PR DESCRIPTION
## What

Every outbound request to the LLM gateway now carries two attribution headers, so gateway spend can be split by app and by which part of the app made the call:

| Header | Value |
| --- | --- |
| `User-Agent` | `reflector/<version>` |
| `x-llmproxy-tags` | `app:reflector,context:<topic\|title\|summary>` |

Contexts are deliberately coarse — three values (`topic`, `title`, `summary`) — which bounds header cardinality and means each `LLM` instance serves exactly one context, so the headers can be baked into the client at construction rather than plumbed per request.

`context` is a **required** keyword-only argument on `LLM`. Required rather than defaulted so a new call site cannot silently land in an untagged bucket, which is the whole point of the change.

All 9 construction sites are tagged:

| File | Context |
| --- | --- |
| `processors/transcript_topic_detector.py` | `topic` |
| `hatchet/workflows/topic_chunk_processing.py` | `topic` |
| `processors/transcript_final_title.py` | `title` |
| `processors/transcript_final_summary.py` | `summary` |
| `hatchet/workflows/subject_processing.py` | `summary` |
| `hatchet/workflows/daily_multitrack_pipeline.py` (x3) | `summary` |
| `processors/summary/summary_builder.py` (demo `main()`) | `summary` |

Version comes from a new `REFLECTOR_VERSION` setting (default `dev`), injected into the backend image as a build arg and fed from the release tag in CI. `docker/metadata-action` strips the `v` prefix, so tag `v0.45.0` yields `reflector/0.45.0`.

Scope is the LLM gateway only (`settings.LLM_URL`). Modal endpoints (Whisper transcription, diarization, translation) are untouched — they do not sit behind the llmproxy.

## A correctness fix that came with it

`_configure_llamaindex()` assigned only the llama-index **process global** `Settings.llm`, and both entry points (`get_response` via `TreeSummarize`, `get_structured_response` via `astructured_predict`) read that global rather than the instance. When two `LLM` objects exist concurrently in one process the last one constructed won for everyone.

That happens routinely: the live pipeline runs the title and summary processors in the same process via `ThreadedProcessor`, and a Hatchet worker runs several tasks per slot. This already mis-attributed `litellm_session_id` and silently applied the wrong `temperature`; it would also have sent the wrong context tag, defeating the purpose of this change.

The client is now scoped to the instance and used directly by both entry points. `Settings.llm` is still assigned for anything else reading the global.

**Behaviour note worth flagging:** this also makes `temperature` correct per instance, where it was not before. Titles and summaries now use their intended temperatures (0.5 and 0.4) instead of whichever `LLM` was constructed last, so generated output may shift slightly.

## Testing

- New `server/tests/test_llm_headers.py` (9 tests): exact header strings, context flows into tags, version flows into `User-Agent`, `context` is required, two concurrent instances keep their own headers, and — the one that actually matters — the headers reach the underlying OpenAI SDK client via `_get_client()`, not just the llama-index wrapper.
- `server/tests/test_llm_retry.py`: the 11 `patch("reflector.llm.Settings")` sites no longer intercept anything now that entry points use `self._llm`, so they were migrated to `patch.object(llm, "_llm")`. The 4 `TreeSummarize` patches were unaffected.
- Full backend suite: **685 passed, 8 skipped**. Verified `default_headers` is supported on the pinned `OpenAILike` and that `TreeSummarize` accepts `llm=` before writing any code.
- Integration tests were not run (excluded by default; they need Docker and external credentials).

One flake seen: `test_transcripts_rtc_ws.py::test_transcript_rtc_and_websocket` failed on the first full run and passed on two subsequent full runs plus in isolation. WebRTC timing, unrelated to this change.

## Follow-ups

- Anything not built by the release workflow (local runs, docker-compose, self-hosted images) reports `reflector/dev` until `REFLECTOR_VERSION` is set. Passing it through the compose files is a small follow-up if wanted.
- If context granularity ever needs to be finer than these three values, static `default_headers` stops working — `SummaryBuilder` alone issues six prompt types through one shared instance. The upgrade path is a `ContextVar` plus an `httpx` request event hook. Noted so the choice is reversible.
