### PR TITLE
feat(www): show room and date on the transcript detail page

### DIFF
--- a/www/app/(app)/transcripts/[transcriptId]/page.tsx
+++ b/www/app/(app)/transcripts/[transcriptId]/page.tsx
@@ -18,12 +18,16 @@ import {
   Flex,
   Grid,
   GridItem,
+  Link,
   Skeleton,
   Text,
   Spinner,
 } from "@chakra-ui/react";
+import NextLink from "next/link";
 import { useTranscriptGet } from "../../../lib/apiHooks";
-import { TranscriptStatus } from "../../../lib/transcript";
+import { TranscriptStatus, transcriptSource } from "../../../lib/transcript";
+import { formatLocalDate } from "../../../lib/time";
+import { roomUrl } from "../../../lib/routes";
 import { useAuth } from "../../../lib/AuthProvider";
 import { featureEnabled } from "../../../lib/features";
 
@@ -32,6 +36,48 @@ type TranscriptDetails = {
     transcriptId: string;
   }>;
 };
+
+// Where the meeting happened and when, shown under the title.
+function TranscriptMeta({
+  transcript,
+}: {
+  transcript: NonNullable<ReturnType<typeof useTranscriptGet>["data"]>;
+}) {
+  const source = transcriptSource(transcript);
+  return (
+    <Flex
+      direction={{ base: "column", md: "row" }}
+      gap={{ base: 1, md: 2 }}
+      fontSize="xs"
+      color="gray.600"
+      flexWrap="wrap"
+      align={{ base: "flex-start", md: "center" }}
+      mt={1}
+    >
+      <Flex align="center" gap={1}>
+        <Text fontWeight="medium" color="gray.500">
+          {transcript.source_kind === "room" ? "Room:" : "Source:"}
+        </Text>
+        {source.roomName ? (
+          <Link as={NextLink} href={roomUrl(source.roomName)}>
+            {source.label}
+          </Link>
+        ) : (
+          <Text>{source.label}</Text>
+        )}
+      </Flex>
+      <Text display={{ base: "none", md: "block" }} color="gray.400">
+        •
+      </Text>
+      <Flex align="center" gap={1}>
+        <Text fontWeight="medium" color="gray.500">
+          Date:
+        </Text>
+        <Text>{formatLocalDate(transcript.created_at)}</Text>
+      </Flex>
+    </Flex>
+  );
+}
 
 export default function TranscriptDetails(details: TranscriptDetails) {
   const params = use(details.params);
@@ -213,6 +259,9 @@ export default function TranscriptDetails(details: TranscriptDetails) {
                   videoNewBadge={videoNewBadge}
                 />
               </Flex>
+              {transcript.data && (
+                <TranscriptMeta transcript={transcript.data} />
+              )}
               {mp3.audioDeleted && (
                 <Text fontSize="xs" color="gray.600" fontStyle="italic">
                   No audio is available because one or more participants didn't

--- a/www/app/lib/__tests__/transcript.test.ts
+++ b/www/app/lib/__tests__/transcript.test.ts
@@ -1,0 +1,54 @@
+import { transcriptSource } from "../transcript";
+
+describe("transcriptSource", () => {
+  it("returns the room name and a linkable room for room transcripts", () => {
+    expect(
+      transcriptSource({
+        source_kind: "room",
+        room_name: "team-standup",
+        room_id: "room-123",
+      }),
+    ).toEqual({ label: "team-standup", roomName: "team-standup" });
+  });
+
+  it("falls back to the room id when the room name is missing", () => {
+    expect(
+      transcriptSource({
+        source_kind: "room",
+        room_name: null,
+        room_id: "room-123",
+      }),
+    ).toEqual({ label: "room-123", roomName: null });
+  });
+
+  it("falls back to the source kind when a room transcript has no room at all", () => {
+    expect(
+      transcriptSource({
+        source_kind: "room",
+        room_name: null,
+        room_id: null,
+      }),
+    ).toEqual({ label: "room", roomName: null });
+  });
+
+  it("uses the source kind for live and file transcripts", () => {
+    expect(transcriptSource({ source_kind: "live" })).toEqual({
+      label: "live",
+      roomName: null,
+    });
+    expect(transcriptSource({ source_kind: "file" })).toEqual({
+      label: "file",
+      roomName: null,
+    });
+  });
+
+  it("ignores blank room names and ids", () => {
+    expect(
+      transcriptSource({
+        source_kind: "room",
+        room_name: "   ",
+        room_id: "",
+      }),
+    ).toEqual({ label: "room", roomName: null });
+  });
+});

--- a/www/app/lib/transcript.ts
+++ b/www/app/lib/transcript.ts
@@ -1,6 +1,34 @@
 import { components } from "../reflector-api";
+import { NonEmptyString, parseMaybeNonEmptyString } from "./utils";
 
 type ApiTranscriptStatus =
   components["schemas"]["GetTranscriptWithParticipants"]["status"];
 
 export type TranscriptStatus = ApiTranscriptStatus;
+
+type SourceKind = components["schemas"]["SourceKind"];
+
+export type TranscriptSource = {
+  // what to display: room name, room id, or the source kind
+  label: string;
+  // set only when the room page can be linked to
+  roomName: NonEmptyString | null;
+};
+
+/**
+ * Describe where a transcript comes from: a named room, or its source kind
+ * for live/file transcripts (which have no room).
+ */
+export const transcriptSource = (transcript: {
+  source_kind: SourceKind;
+  room_name?: string | null;
+  room_id?: string | null;
+}): TranscriptSource => {
+  if (transcript.source_kind !== "room") {
+    return { label: transcript.source_kind, roomName: null };
+  }
+  const roomName = parseMaybeNonEmptyString(transcript.room_name || "");
+  if (roomName) return { label: roomName, roomName };
+  const roomId = parseMaybeNonEmptyString(transcript.room_id || "");
+  return { label: roomId || transcript.source_kind, roomName: null };
+};


### PR DESCRIPTION
## What

The transcript detail page (`/transcripts/:id`) showed the title, summary and topics, but nothing about **which room** the meeting happened in or **when** it took place. This adds a metadata line directly under the title:

```
Weekly engineering sync                      [edit] [copy] [share]
Room: team-standup • Date: August 21, 2026 at 3:04 PM
```

- For `source_kind === "room"`, the room name links to the room page via `roomUrl()`.
- For `live` / `file` transcripts there is no room, so the label reads `Source:` and shows the source kind instead, mirroring what the browse cards already do.
- Fallback chain is room name → room id → source kind, so the line is never half-empty.

## Why

Users landing on a transcript had no way to tell where it came from or when it happened without going back to the browse list.

## How

Frontend only. `GET /v1/transcripts/{id}` already returns `created_at`, `source_kind`, `room_id` and `room_name` (resolved in `server/reflector/views/transcripts.py`), so there is no schema change and no `pnpm openapi` re-run.

- `www/app/lib/transcript.ts` — new `transcriptSource()` holding the fallback chain. It returns the room name separately from the display label so the caller knows when a link to the room page is possible.
- `www/app/(app)/transcripts/[transcriptId]/page.tsx` — new `TranscriptMeta` row, slotted into the existing column `Flex` between the title row and the "audio deleted" notice. It reuses the exact responsive layout from the browse cards (`TranscriptCards.tsx`): row on desktop, stacked column on mobile with the bullet separator hidden.

`TranscriptTitle` is deliberately untouched — its non-edit branch is a single-row `Flex` with `Spacer` plus action buttons, and restructuring it risks regressions in edit mode.

## Testing

- New unit tests in `www/app/lib/__tests__/transcript.test.ts` cover every rung of the fallback: named room, room id only, room with neither, live/file sources, and blank-string room fields. Written test-first.
- Full frontend suite passes (11 tests), `tsc --noEmit` clean.
- Verified visually against a local stack (FastAPI on :1250 with Postgres, Next dev on :3000, seeded room + transcript) screenshotted with headless Chrome in Docker at both 1440px and 390px, plus a `file`-source transcript to exercise the non-room path.

## Notes

- The Next dev overlay reports the same issue count on this page with and without the new component, so it introduces no new console errors. (The seeded transcript has no audio file, which is what that pre-existing issue is.)
- `formatLocalDate` reads `navigator.language`; the row is guarded on `transcript.data`, so it only renders after the query resolves and cannot cause a hydration mismatch.

## Follow-ups

- The browse cards and this page now render near-identical metadata. If a third consumer appears, it is worth extracting a shared `TranscriptMeta` component; deferred for now since the browse card markup also mixes in duration and search-match concerns.