### PR TITLE
fix(www): stop leaking access and refresh tokens into frontend logs

### DIFF
--- a/.github/workflows/test_next_server.yml
+++ b/.github/workflows/test_next_server.yml
@@ -41,5 +41,8 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    - name: Run lint
+      run: pnpm lint
+
     - name: Run tests
       run: pnpm test

--- a/.github/workflows/test_next_server.yml
+++ b/.github/workflows/test_next_server.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 8
+        version: 10
 
     - name: Setup Node.js cache
       uses: actions/setup-node@v4

--- a/www/app/lib/authBackend.ts
+++ b/www/app/lib/authBackend.ts
@@ -33,11 +33,7 @@ async function getUserId(accessToken: string): Promise<string | null> {
     });
 
     if (!response.ok) {
-      try {
-        console.error(await response.text());
-      } catch (e) {
-        console.error("Failed to parse error response", e);
-      }
+      console.error("Failed to fetch user id from backend", response.status);
       return null;
     }
 
@@ -317,8 +313,6 @@ async function refreshAccessToken(token: JWT): Promise<JWTWithAccessToken> {
         "Failed to refresh access token. Response status:",
         response.status,
       );
-      const responseBody = await response.text();
-      console.error(new Date().toISOString(), "Response body:", responseBody);
       throw new Error(`Failed to refresh access token: ${response.statusText}`);
     }
     const refreshedTokens = await response.json();

--- a/www/app/lib/authBackend.ts
+++ b/www/app/lib/authBackend.ts
@@ -213,13 +213,6 @@ function authentikAuthOptions(): AuthOptions {
           tokenCacheRedis,
           `token:${token.sub}`,
         );
-        console.debug(
-          "currentToken from cache",
-          JSON.stringify(currentToken, null, 2),
-          "will be returned?",
-          currentToken &&
-            !shouldRefreshToken(currentToken.token.accessTokenExpires),
-        );
         if (
           currentToken &&
           !shouldRefreshToken(currentToken.token.accessTokenExpires)
@@ -232,7 +225,6 @@ function authentikAuthOptions(): AuthOptions {
       },
       async session({ session, token }) {
         const extendedToken = token as JWTWithAccessToken;
-        console.log("extendedToken", extendedToken);
         const userId = await getUserId(extendedToken.accessToken);
 
         return {
@@ -259,26 +251,16 @@ async function lockedRefreshAccessToken(
   return redlock
     .using([lockKey], 10000, async () => {
       const cached = await getTokenCache(tokenCacheRedis, `token:${token.sub}`);
-      if (cached)
-        console.debug(
-          "received cached token. to delete?",
-          Date.now() - cached.timestamp > TOKEN_CACHE_TTL,
-        );
-      else console.debug("no cached token received");
       if (cached) {
         if (Date.now() - cached.timestamp > TOKEN_CACHE_TTL) {
           await deleteTokenCache(tokenCacheRedis, `token:${token.sub}`);
         } else if (!shouldRefreshToken(cached.token.accessTokenExpires)) {
-          console.debug("returning cached token", cached.token);
           return cached.token;
         }
       }
 
       const currentToken = cached?.token || (token as JWTWithAccessToken);
       const newToken = await refreshAccessToken(currentToken);
-
-      console.debug("current token during refresh", currentToken);
-      console.debug("new token during refresh", newToken);
 
       if (newToken.error) {
         await deleteTokenCache(tokenCacheRedis, `token:${token.sub}`);

--- a/www/app/lib/redisTokenCache.ts
+++ b/www/app/lib/redisTokenCache.ts
@@ -39,7 +39,13 @@ export async function getTokenCache(
   try {
     return TokenCacheEntryCodec.decode(data);
   } catch (error) {
-    console.error("Invalid token cache data:", error);
+    // Never log the error itself: it is raised over the serialized token blob,
+    // and both JSON.parse and zod echo fragments of their input in the message.
+    console.error(
+      "Invalid token cache data, dropping entry",
+      key,
+      error instanceof Error ? error.name : "unknown error",
+    );
     await redis.del(key);
     return null;
   }

--- a/www/app/login/page.tsx
+++ b/www/app/login/page.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
     setLoading(false);
 
     if (result?.error) {
-      console.log(result?.error);
+      console.error("sign-in failed:", result?.error);
       setError("Invalid email or password");
     } else {
       router.push("/");

--- a/www/eslint.config.mjs
+++ b/www/eslint.config.mjs
@@ -1,0 +1,28 @@
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  {
+    ignores: [".next/", "coverage/", "public/", "app/reflector-api.d.ts"],
+  },
+  {
+    // Auth modules handle access/refresh tokens. console.log/debug/info is how
+    // those tokens ended up in the server logs, so the whole class of statement
+    // is banned here. console.error/warn stay allowed for genuine failure
+    // paths, but must never be handed a token or a raw token payload.
+    files: [
+      "app/lib/authBackend.ts",
+      "app/lib/redisTokenCache.ts",
+      "app/lib/redisClient.ts",
+      "app/lib/types.ts",
+      "app/lib/AuthProvider.tsx",
+      "app/lib/SessionAutoRefresh.tsx",
+      "app/login/page.tsx",
+      "app/api/auth/**/*.ts",
+      "proxy.ts",
+    ],
+    languageOptions: { parser: tsParser },
+    rules: {
+      "no-console": ["error", { allow: ["error", "warn"] }],
+    },
+  },
+];

--- a/www/package.json
+++ b/www/package.json
@@ -72,15 +72,5 @@
     "openapi-typescript": "^7.13.0",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6"
-  },
-  "pnpm": {
-    "overrides": {
-      "minimatch@>=5.0.0 <5.1.8": "5.1.8",
-      "js-yaml@<4.1.1": "4.1.1",
-      "webpack": "5.105.3",
-      "serialize-javascript": "7.0.4",
-      "immutable": "5.1.5",
-      "next": "16.1.7"
-    }
   }
 }

--- a/www/package.json
+++ b/www/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "build-production": "next build --experimental-build-mode compile",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "openapi": "openapi-typescript http://127.0.0.1:1250/openapi.json -o ./app/reflector-api.d.ts",
     "test": "jest",
@@ -64,6 +64,7 @@
   "license": "All Rights Reserved",
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",
+    "@typescript-eslint/parser": "^8.56.1",
     "@types/jest": "^30.0.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/www/pnpm-lock.yaml
+++ b/www/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/parser':
+        specifier: ^8.56.1
+        version: 8.56.1(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3)
       jest:
         specifier: ^30.2.0
         version: 30.2.0(@types/node@25.3.2)(babel-plugin-macros@3.1.0)
@@ -2093,6 +2096,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@ungap/trim@0.2.0':
     resolution: {integrity: sha512-CfsUxeZ2R/O3EGCOe+IkAU32yHOdO+mCRmtavSIQ4HZN3Jiq/ynGzq8/asyamd28U26UJmpSV/TC7+p7qELKrg==}
@@ -3573,6 +3577,7 @@ packages:
 
   ip-range-check@0.0.2:
     resolution: {integrity: sha512-sHbyog8viObPK2vZFNYpBM/d2mqs51uuxOhB+0EIMSWmmrflAWne7CeXOWunb5R6bWQVOijbLx7bEY0sE05bug==}
+    deprecated: Contains an SSRF filter-bypass vulnerability, upgrade to 0.2.1+ — see GHSA advisory
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4809,7 +4814,7 @@ packages:
     hasBin: true
 
   rtcstats@https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d:
-    resolution: {tarball: https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d}
+    resolution: {gitHosted: true, integrity: sha512-BnF/muPj+fsqqbtc8XRV0SInpdR1qXnc6s3m7QDxU1MFw6sGeKW61xP43rn792ReD7fXxibNcoQ/7RvSfrpNDQ==, tarball: https://codeload.github.com/whereby/rtcstats/tar.gz/63bcb6420d76d34161b39e494524ae73aa6dd70d}
     version: 5.4.1
 
   run-parallel@1.2.0:
@@ -5319,10 +5324,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uwire@1.1.0:

--- a/www/pnpm-workspace.yaml
+++ b/www/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# pnpm settings live here, not in the "pnpm" field of package.json: pnpm 11
+# no longer reads that field, and silently re-resolves without these pins if
+# they are left there. Keep security overrides in this file only.
+#
+# Requires pnpm >= 10. pnpm 8 fails on this file with
+# ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION.
+overrides:
+  "minimatch@>=5.0.0 <5.1.8": "5.1.8"
+  "js-yaml@<4.1.1": "4.1.1"
+  webpack: "5.105.3"
+  serialize-javascript: "7.0.4"
+  immutable: "5.1.5"
+  next: "16.1.7"


### PR DESCRIPTION
## What

The Next.js frontend was printing OAuth **access tokens and refresh tokens** into its server logs. This removes them, hardens the surrounding error logs, and adds a lint rule so the same class of statement cannot come back.

### The leak

Five statements in the NextAuth `jwt` / `session` callbacks in `www/app/lib/authBackend.ts` logged whole JWT objects. `JWTWithAccessToken` is `{ accessToken, accessTokenExpires, refreshToken?, error? }`, so each one printed live credentials:

| Line | Statement | Printed |
| --- | --- | --- |
| 216-222 | `console.debug("currentToken from cache", JSON.stringify(currentToken, null, 2), ...)` | Pretty-printed cache entry: access **and** refresh token |
| 235 | `console.log("extendedToken", extendedToken)` | Whole JWT, on **every** session callback |
| 262-267 | `console.debug("received cached token. to delete?", ...)` / `"no cached token received"` | Leftover debug noise |
| 272 | `console.debug("returning cached token", cached.token)` | Whole cached JWT |
| 280-281 | `console.debug("current token during refresh"/"new token during refresh", ...)` | Old refresh token **and the freshly minted one** |

These run server-side in the Next process, which is the log the leak was spotted in. `@sentry/nextjs` also captures `console.*` as breadcrumbs, so they could be shipped to Sentry attached to any later error. `next.config.js` sets no `compiler.removeConsole`, and it would not have helped anyway since that only strips client bundles.

### Changes

- **`fa54e345`** — delete all five token dumps. Control flow is unchanged: the `return cached.token` and the `if` / `else if` structure in `lockedRefreshAccessToken` are preserved, and the log-only `if/else` at 262-267 is removed whole rather than left as an empty block.
- **`28e53f76`** — stop echoing raw payloads in the adjacent error logs:
  - `getUserId` logged the unlabeled raw body of a failed `/v1/me` response; now logs the status.
  - `refreshAccessToken` logged the raw body of a failed Authentik token request; the status is already logged and the thrown `Error` carries `statusText`.
  - `getTokenCache` logged the decode error verbatim. Both `JSON.parse` and zod echo fragments of their input in the message, and the input there is the serialized token blob. Now logs the cache key and `error.name` only.
  - `login/page.tsx` logged the sign-in error unlabeled; now labelled.
- **`f10fb305`** — add `www/eslint.config.mjs`: a flat config with one rule, `no-console` allowing only `error`/`warn`, scoped to the auth modules. Deliberately narrow so it cannot turn CI red on unrelated legacy code. Also replaces the dead `next lint` script (removed in Next 16) with `eslint .` and runs it in the frontend workflow.
- **`f7a628ce`** — see below.

## Why the pnpm change is in this PR

Adding a devDependency meant touching the lockfile, which surfaced a live problem worth fixing here rather than leaving armed.

**pnpm 11 no longer reads the `pnpm` field in `package.json`.** A lockfile written by pnpm 11 silently drops the security overrides. Observed on the first attempt: `js-yaml` 4.1.1 → 4.1.0/3.15.1 and `minimatch` 5.1.8 → 5.1.6, i.e. back to exactly the versions those pins exist to avoid. That lockfile was discarded.

The overrides now live in `www/pnpm-workspace.yaml`, which pnpm 10 and 11 both read.

**The CI pnpm bump (8 → 10) is required, not cosmetic:**
- pnpm 8 fails outright on that file with `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION: packages field missing or empty`, and would not read the overrides from it in any case.
- Separately, CI was logging `WARN Ignoring not compatible lockfile` — pnpm 8.15.9 cannot read the v9 lockfile, so it discarded it and re-resolved from the registry on every run. CI has not been installing the locked tree at all. `pnpm.overrides` was the only thing holding the security versions there.
- pnpm 10 is what `pre-commit.yml` already uses, so it is a combination already proven in this CI.

`@typescript-eslint/parser` is pinned at `^8.56.1`, the version already resolved transitively via `eslint-config-next`, so the lockfile gains only a 3-line importer entry.

## Testing

```
eslint .        exit 0
tsc --noEmit    exit 0
jest            3 suites, 6 tests passed
grep -rnE "console\.(log|debug|info)\(.*[Tt]oken" app    no matches
```

The guardrail was checked to actually bite, not merely to pass: re-inserting the exact leaking statement (`console.log("extendedToken", extendedToken)`) makes `eslint` exit 1 with `no-console` at that line; removing it returns 0.

The pnpm migration was verified empirically rather than assumed:
- Lockfile is **byte-identical** under pnpm 10 and pnpm 11 with the migrated config — zero churn.
- `CI=true pnpm@10 install --frozen-lockfile` exits **0** (pnpm 11 exits 1 on `ERR_PNPM_IGNORED_BUILDS`, which is why CI is pinned to 10).
- Installed tree still resolves js-yaml only at 4.1.1, minimatch 5.1.8 with nothing in the vulnerable `>=5.0.0 <5.1.8` range, webpack 5.105.3, immutable 5.1.5.

Remaining `console.error` calls that mention "token" (`authBackend.ts:278,280,326`, `SessionAutoRefresh.tsx:32`) name it in the message string only and pass an `Error`, not a token value.

**Not verified:** manual browser smoke test against a live Authentik (sign in, wait for a refresh, confirm no `eyJ...` in the server console). Requires a running Authentik instance.

## Follow-ups (not in this PR)

- **This diff does not undo the exposure.** Tokens already written to container logs, and possibly shipped to Sentry as breadcrumbs, are still there. Refresh tokens are long-lived, so anything captured stays usable until revoked. Worth deciding on: rotating the Authentik client secret if it shared that log stream, invalidating outstanding refresh tokens, and purging/shortening retention on the affected log and Sentry projects.
- **Loss of refresh-flow diagnostics.** The deleted statements were the only visibility into the cache-hit / refresh path. This was the accepted trade-off; `app/lib/__tests__/authBackend.test.ts` still covers the refresh request shape. Anything re-added later should be redacted.
- **Sentry `beforeBreadcrumb` scrubber** would blunt future accidents, but does nothing about plain stdout, which is what was actually read here.
- **pnpm 11 still exits 1 on `ERR_PNPM_IGNORED_BUILDS`** (`sharp`, `@sentry/cli`, `@parcel/watcher`, `unrs-resolver`). This breaks `pnpm format` and so the `format` pre-commit hook for local pnpm 11 users. The fix is an `onlyBuiltDependencies` list in `pnpm-workspace.yaml`, but that starts actually compiling those native packages during install, which is a behaviour change beyond this PR.
