### PR TITLE
fix: allow rejoining a long-running meeting

### DIFF
--- a/server/reflector/dailyco_api/__init__.py
+++ b/server/reflector/dailyco_api/__init__.py
@@ -13,6 +13,7 @@ from .requests import (
     MeetingTokenProperties,
     RecordingsBucketConfig,
     RoomProperties,
+    UpdateRoomRequest,
     UpdateWebhookRequest,
 )
 
@@ -72,6 +73,7 @@ __all__ = [
     "CreateMeetingTokenRequest",
     "MeetingTokenProperties",
     "CreateWebhookRequest",
+    "UpdateRoomRequest",
     "UpdateWebhookRequest",
     # Responses
     "RoomResponse",

--- a/server/reflector/dailyco_api/client.py
+++ b/server/reflector/dailyco_api/client.py
@@ -19,6 +19,7 @@ from .requests import (
     CreateMeetingTokenRequest,
     CreateRoomRequest,
     CreateWebhookRequest,
+    UpdateRoomRequest,
     UpdateWebhookRequest,
 )
 from .responses import (
@@ -177,6 +178,35 @@ class DailyApiClient:
         )
 
         data = await self._handle_response(response, "create_room")
+        return RoomResponse(**data)
+
+    async def update_room(
+        self, room_name: NonEmptyString, request: UpdateRoomRequest
+    ) -> RoomResponse:
+        """
+        Update the configuration of an existing room.
+
+        Reference: https://docs.daily.co/reference/rest-api/rooms/set-room-config
+
+        Args:
+            room_name: Daily.co room name
+            request: Properties to update. Only the properties explicitly set on
+                the request are sent, leaving the other room settings untouched.
+
+        Returns:
+            Updated room data
+
+        Raises:
+            DailyApiError: If API request fails
+        """
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.base_url}/rooms/{room_name}",
+            headers=self.headers,
+            json=request.model_dump(exclude_none=True, exclude_unset=True),
+        )
+
+        data = await self._handle_response(response, "update_room")
         return RoomResponse(**data)
 
     async def get_room(self, room_name: NonEmptyString) -> RoomResponse:

--- a/server/reflector/dailyco_api/requests.py
+++ b/server/reflector/dailyco_api/requests.py
@@ -74,6 +74,19 @@ class CreateRoomRequest(BaseModel):
     )
 
 
+class UpdateRoomRequest(BaseModel):
+    """
+    Request to update an existing Daily.co room.
+
+    Only the properties explicitly set on `properties` are sent, so an update
+    never resets unrelated room settings.
+
+    Reference: https://docs.daily.co/reference/rest-api/rooms/set-room-config
+    """
+
+    properties: RoomProperties = Field(description="Room properties to update")
+
+
 class MeetingTokenProperties(BaseModel):
     """
     Properties for meeting token creation.

--- a/server/reflector/video_platforms/base.py
+++ b/server/reflector/video_platforms/base.py
@@ -30,6 +30,19 @@ class VideoPlatformClient(ABC):
         """Get session history for a room."""
         pass
 
+    async def extend_meeting_expiration(
+        self, room_name: str, end_date: datetime
+    ) -> bool:
+        """Push the platform-side room expiration to a later date.
+
+        Called while a meeting is still running so participants can rejoin past
+        the initially planned end date.
+
+        No-op by default: Whereby has no room update API, and LiveKit rooms have
+        no wall-clock expiry. Returns True when the platform expiry was updated.
+        """
+        return False
+
     @abstractmethod
     async def upload_logo(self, room_name: str, logo_path: str) -> bool:
         pass

--- a/server/reflector/video_platforms/daily.py
+++ b/server/reflector/video_platforms/daily.py
@@ -11,6 +11,7 @@ from reflector.dailyco_api import (
     RecordingsBucketConfig,
     RoomPresenceResponse,
     RoomProperties,
+    UpdateRoomRequest,
     verify_webhook_signature,
 )
 from reflector.dailyco_api import RecordingType as DailyRecordingType
@@ -124,6 +125,30 @@ class DailyClient(VideoPlatformClient):
             )
             for s in sessions
         ]
+
+    async def extend_meeting_expiration(
+        self, room_name: str, end_date: datetime
+    ) -> bool:
+        """Move the Daily room `exp` forward so participants can still rejoin.
+
+        Failures are logged and reported, not raised: the caller retries on the
+        next pass.
+        """
+        try:
+            await self._api_client.update_room(
+                room_name,
+                UpdateRoomRequest(
+                    properties=RoomProperties(exp=int(end_date.timestamp()))
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to extend Daily room expiration",
+                room_name=room_name,
+                exc_info=True,
+            )
+            return False
+        return True
 
     async def get_room_presence(self, room_name: str) -> RoomPresenceResponse:
         """Get room presence/session data for a Daily.co room."""

--- a/server/reflector/worker/process.py
+++ b/server/reflector/worker/process.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Literal
 from urllib.parse import unquote
 
@@ -55,6 +55,13 @@ from reflector.video_platforms.whereby_utils import (
 )
 
 logger = structlog.wrap_logger(get_task_logger(__name__))
+
+# A meeting that is still running gets its end date pushed forward, so
+# participants can leave and rejoin a meeting that outlives its planned end.
+# The extension is applied only once the remaining time drops below the
+# threshold, which keeps the extra platform API calls to one every few hours.
+MEETING_EXTENSION_THRESHOLD = timedelta(hours=4)
+MEETING_EXTENSION_DURATION = timedelta(hours=8)
 
 
 @shared_task
@@ -824,11 +831,52 @@ async def poll_daily_room_presence_task(meeting_id: str) -> None:
     await poll_daily_room_presence(meeting_id)
 
 
+async def extend_meeting_lease(meeting, client, end_date, current_time) -> None:
+    """Push `end_date` forward for a meeting that is still running.
+
+    Meetings are created with a fixed end date. Without this, a meeting that
+    outlives that date stays active but is refused by the join endpoint
+    ("Meeting has ended") and disappears from the active meeting lists, so a
+    participant who leaves cannot come back.
+
+    The platform-side expiration is updated as well (Daily rooms carry their own
+    `exp`). A platform failure is logged and the database is still extended:
+    participants already in the meeting are unaffected, and the join endpoint
+    stops refusing them on our side.
+    """
+    if end_date - current_time >= MEETING_EXTENSION_THRESHOLD:
+        return
+
+    new_end_date = current_time + MEETING_EXTENSION_DURATION
+
+    try:
+        await client.extend_meeting_expiration(meeting.room_name, new_end_date)
+    except Exception:
+        logger.warning(
+            "Failed to extend platform meeting expiration",
+            meeting_id=meeting.id,
+            room_name=meeting.room_name,
+            exc_info=True,
+        )
+
+    await meetings_controller.update_meeting(meeting.id, end_date=new_end_date)
+    logger.info(
+        "Meeting end date extended - still running",
+        meeting_id=meeting.id,
+        room_name=meeting.room_name,
+        previous_end_date=end_date.isoformat(),
+        new_end_date=new_end_date.isoformat(),
+    )
+
+
 @shared_task
 @asynctask
 async def process_meetings():
     """
     Checks which meetings are still active and deactivates those that have ended.
+
+    Meetings with active sessions also get their end date extended when they
+    are about to expire (see extend_meeting_lease).
 
     Deactivation logic:
     - Active sessions: Keep meeting active regardless of scheduled time
@@ -886,6 +934,7 @@ async def process_meetings():
 
                 if has_active_sessions:
                     logger_.debug("Meeting still has active sessions, keep it")
+                    await extend_meeting_lease(meeting, client, end_date, current_time)
                 elif has_had_sessions:
                     should_deactivate = True
                     logger_.info("Meeting ended - all participants left")

--- a/server/tests/test_meeting_extension.py
+++ b/server/tests/test_meeting_extension.py
@@ -1,0 +1,289 @@
+"""Tests for the meeting lease extension.
+
+A meeting that is still running must not expire: `process_meetings` pushes
+`end_date` forward while the platform reports active sessions, and propagates
+the new expiry to the platform (Daily room `exp`).
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from reflector.dailyco_api import DailyApiClient, RoomProperties, UpdateRoomRequest
+from reflector.db.meetings import meetings_controller
+from reflector.db.rooms import rooms_controller
+from reflector.video_platforms.models import SessionData
+from reflector.worker import process
+from reflector.worker.process import (
+    MEETING_EXTENSION_DURATION,
+    MEETING_EXTENSION_THRESHOLD,
+)
+
+
+def _process_meetings_fn():
+    """Get the underlying async function without the Celery/asynctask decorators."""
+    fn = process.process_meetings
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    return fn
+
+
+process_meetings = _process_meetings_fn()
+
+
+class TestDailyApiClientUpdateRoom:
+    """The Daily REST client can update an existing room."""
+
+    @pytest.mark.asyncio
+    async def test_update_room_posts_only_provided_properties(self):
+        client = DailyApiClient(api_key="test-key")
+        http_client = AsyncMock()
+        http_client.post.return_value = httpx.Response(
+            200,
+            json={
+                "id": "room-id",
+                "name": "test-room",
+                "url": "https://daily.co/test-room",
+                "api_created": True,
+                "privacy": "public",
+                "created_at": "2026-08-21T12:00:00.000Z",
+            },
+            request=httpx.Request("POST", "https://api.daily.co/v1/rooms/test-room"),
+        )
+        client._client = http_client
+
+        result = await client.update_room(
+            "test-room",
+            UpdateRoomRequest(properties=RoomProperties(exp=1234567890)),
+        )
+
+        assert result.name == "test-room"
+        http_client.post.assert_awaited_once()
+        args, kwargs = http_client.post.call_args
+        assert args[0] == "https://api.daily.co/v1/rooms/test-room"
+        # Only explicitly set properties are sent, so unrelated room settings
+        # (knocking, recording, ...) are not reset by the update.
+        assert kwargs["json"] == {"properties": {"exp": 1234567890}}
+
+
+class TestDailyExtendMeetingExpiration:
+    """The Daily platform client propagates the new expiry to the room."""
+
+    @pytest.mark.asyncio
+    async def test_extend_meeting_expiration_updates_room_exp(self):
+        from reflector.video_platforms.daily import DailyClient
+        from reflector.video_platforms.models import VideoPlatformConfig
+
+        client = DailyClient(
+            VideoPlatformConfig(api_key="test-key", webhook_secret="secret")
+        )
+        client._api_client = MagicMock()
+        client._api_client.update_room = AsyncMock()
+
+        end_date = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+        assert await client.extend_meeting_expiration("test-room", end_date) is True
+
+        client._api_client.update_room.assert_awaited_once()
+        room_name, request = client._api_client.update_room.call_args.args
+        assert room_name == "test-room"
+        assert request.properties.exp == int(end_date.timestamp())
+
+    @pytest.mark.asyncio
+    async def test_extend_meeting_expiration_returns_false_on_api_error(self):
+        from reflector.video_platforms.daily import DailyClient
+        from reflector.video_platforms.models import VideoPlatformConfig
+
+        client = DailyClient(
+            VideoPlatformConfig(api_key="test-key", webhook_secret="secret")
+        )
+        client._api_client = MagicMock()
+        client._api_client.update_room = AsyncMock(side_effect=Exception("boom"))
+
+        result = await client.extend_meeting_expiration(
+            "test-room", datetime.now(timezone.utc)
+        )
+
+        assert result is False
+
+
+async def _create_room(name: str = "extension-room"):
+    return await rooms_controller.add(
+        name=name,
+        user_id="test-user",
+        zulip_auto_post=False,
+        zulip_stream="",
+        zulip_topic="",
+        is_locked=False,
+        room_mode="normal",
+        recording_type="cloud",
+        recording_trigger="automatic-2nd-participant",
+        is_shared=False,
+        platform="daily",
+    )
+
+
+def _platform_client(sessions: list[SessionData], extend_result: bool = True):
+    client = MagicMock()
+    client.get_room_sessions = AsyncMock(return_value=sessions)
+    client.extend_meeting_expiration = AsyncMock(return_value=extend_result)
+    return client
+
+
+def _active_session():
+    return SessionData(
+        session_id="session-1",
+        started_at=datetime.now(timezone.utc) - timedelta(hours=7),
+        ended_at=None,
+    )
+
+
+class TestProcessMeetingsExtension:
+    @pytest.mark.asyncio
+    @patch("reflector.worker.process.create_platform_client")
+    async def test_extends_end_date_when_running_and_close_to_expiry(
+        self, mock_create_client
+    ):
+        room = await _create_room("extension-room-close")
+        now = datetime.now(timezone.utc)
+        meeting = await meetings_controller.create(
+            id="meeting-extend-1",
+            room_name="daily-room-extend-1",
+            room_url="https://daily.co/extend-1",
+            host_room_url="https://daily.co/extend-1",
+            start_date=now - timedelta(hours=7),
+            end_date=now + timedelta(hours=1),
+            room=room,
+        )
+        client = _platform_client([_active_session()])
+        mock_create_client.return_value = client
+
+        await process_meetings()
+
+        updated = await meetings_controller.get_by_id(meeting.id)
+        assert updated.is_active is True
+        new_end_date = updated.end_date
+        if new_end_date.tzinfo is None:
+            new_end_date = new_end_date.replace(tzinfo=timezone.utc)
+        expected = now + MEETING_EXTENSION_DURATION
+        assert abs((new_end_date - expected).total_seconds()) < 60
+
+        client.extend_meeting_expiration.assert_awaited_once()
+        room_name, end_date = client.extend_meeting_expiration.call_args.args
+        assert room_name == "daily-room-extend-1"
+        assert abs((end_date - expected).total_seconds()) < 60
+
+    @pytest.mark.asyncio
+    @patch("reflector.worker.process.create_platform_client")
+    async def test_no_extension_when_expiry_is_far_away(self, mock_create_client):
+        room = await _create_room("extension-room-far")
+        now = datetime.now(timezone.utc)
+        original_end_date = now + MEETING_EXTENSION_THRESHOLD + timedelta(hours=1)
+        meeting = await meetings_controller.create(
+            id="meeting-extend-2",
+            room_name="daily-room-extend-2",
+            room_url="https://daily.co/extend-2",
+            host_room_url="https://daily.co/extend-2",
+            start_date=now - timedelta(minutes=10),
+            end_date=original_end_date,
+            room=room,
+        )
+        client = _platform_client([_active_session()])
+        mock_create_client.return_value = client
+
+        await process_meetings()
+
+        updated = await meetings_controller.get_by_id(meeting.id)
+        new_end_date = updated.end_date
+        if new_end_date.tzinfo is None:
+            new_end_date = new_end_date.replace(tzinfo=timezone.utc)
+        assert abs((new_end_date - original_end_date).total_seconds()) < 1
+        client.extend_meeting_expiration.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("reflector.worker.process.create_platform_client")
+    async def test_no_extension_when_no_active_sessions(self, mock_create_client):
+        room = await _create_room("extension-room-idle")
+        now = datetime.now(timezone.utc)
+        original_end_date = now + timedelta(hours=1)
+        meeting = await meetings_controller.create(
+            id="meeting-extend-3",
+            room_name="daily-room-extend-3",
+            room_url="https://daily.co/extend-3",
+            host_room_url="https://daily.co/extend-3",
+            start_date=now - timedelta(hours=7),
+            end_date=original_end_date,
+            room=room,
+        )
+        ended_session = SessionData(
+            session_id="session-ended",
+            started_at=now - timedelta(hours=7),
+            ended_at=now - timedelta(minutes=5),
+        )
+        client = _platform_client([ended_session])
+        mock_create_client.return_value = client
+
+        await process_meetings()
+
+        updated = await meetings_controller.get_by_id(meeting.id)
+        new_end_date = updated.end_date
+        if new_end_date.tzinfo is None:
+            new_end_date = new_end_date.replace(tzinfo=timezone.utc)
+        assert abs((new_end_date - original_end_date).total_seconds()) < 1
+        client.extend_meeting_expiration.assert_not_awaited()
+        # everyone left: the meeting is deactivated as before
+        assert updated.is_active is False
+
+    @pytest.mark.asyncio
+    @patch("reflector.worker.process.create_platform_client")
+    async def test_join_succeeds_after_extension(self, mock_create_client, client):
+        """Regression: a long-running meeting can still be joined after its
+        original end date."""
+        room = await _create_room("extension-room-join")
+        now = datetime.now(timezone.utc)
+        meeting = await meetings_controller.create(
+            id="meeting-extend-join",
+            room_name="daily-room-extend-join",
+            room_url="https://daily.co/extend-join",
+            host_room_url="https://daily.co/extend-join",
+            start_date=now - timedelta(hours=9),
+            end_date=now - timedelta(minutes=5),
+            room=room,
+        )
+        mock_create_client.return_value = _platform_client([_active_session()])
+
+        await process_meetings()
+
+        response = await client.post(f"/rooms/{room.name}/meetings/{meeting.id}/join")
+        assert response.status_code == 200, response.text
+
+    @pytest.mark.asyncio
+    @patch("reflector.worker.process.create_platform_client")
+    async def test_db_extension_applies_even_if_platform_call_fails(
+        self, mock_create_client
+    ):
+        room = await _create_room("extension-room-failing")
+        now = datetime.now(timezone.utc)
+        meeting = await meetings_controller.create(
+            id="meeting-extend-4",
+            room_name="daily-room-extend-4",
+            room_url="https://daily.co/extend-4",
+            host_room_url="https://daily.co/extend-4",
+            start_date=now - timedelta(hours=7),
+            end_date=now + timedelta(hours=1),
+            room=room,
+        )
+        client = _platform_client([_active_session()])
+        client.extend_meeting_expiration = AsyncMock(side_effect=Exception("boom"))
+        mock_create_client.return_value = client
+
+        await process_meetings()
+
+        updated = await meetings_controller.get_by_id(meeting.id)
+        assert updated.is_active is True
+        new_end_date = updated.end_date
+        if new_end_date.tzinfo is None:
+            new_end_date = new_end_date.replace(tzinfo=timezone.utc)
+        expected = now + MEETING_EXTENSION_DURATION
+        assert abs((new_end_date - expected).total_seconds()) < 60

--- a/www/app/[roomName]/components/DailyRoom.tsx
+++ b/www/app/[roomName]/components/DailyRoom.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Box, Spinner, Center, Text } from "@chakra-ui/react";
+import { Box, Spinner, Center } from "@chakra-ui/react";
 import { useRouter, useParams } from "next/navigation";
 import DailyIframe, {
   DailyCall,
@@ -28,7 +28,8 @@ import {
   useRoomJoinMeeting,
   useMeetingStartRecording,
 } from "../../lib/apiHooks";
-import { formatJoinError } from "../../lib/errorUtils";
+import { describeJoinError } from "../../lib/errorUtils";
+import MeetingErrorScreen from "./MeetingErrorScreen";
 import { omit } from "remeda";
 import {
   assertExists,
@@ -192,6 +193,7 @@ export default function DailyRoom({ meeting, room }: DailyRoomProps) {
   const joinMutation = useRoomJoinMeeting();
   const startRecordingMutation = useMeetingStartRecording();
   const [joinedMeeting, setJoinedMeeting] = useState<Meeting | null>(null);
+  const [joinAttempt, setJoinAttempt] = useState(0);
 
   // Generate deterministic instanceIds so all participants use SAME IDs
   const cloudInstanceId = parseNonEmptyString(meeting.id);
@@ -244,7 +246,12 @@ export default function DailyRoom({ meeting, room }: DailyRoomProps) {
     };
 
     join().catch(console.error.bind(console, "Failed to join meeting:"));
-  }, [meeting?.id, roomName, authLastUserId]);
+  }, [meeting?.id, roomName, authLastUserId, joinAttempt]);
+
+  const handleRetryJoin = useCallback(() => {
+    joinMutation.reset();
+    setJoinAttempt((attempt) => attempt + 1);
+  }, [joinMutation]);
 
   const roomUrl = joinedMeeting?.room_url;
 
@@ -427,10 +434,14 @@ export default function DailyRoom({ meeting, room }: DailyRoomProps) {
   }
 
   if (joinMutation.isError) {
+    const { title, message, canRetry } = describeJoinError(joinMutation.error);
     return (
-      <Center width="100vw" height="100vh">
-        <Text color="red.500">{formatJoinError(joinMutation.error)}</Text>
-      </Center>
+      <MeetingErrorScreen
+        title={title}
+        message={message}
+        roomName={roomName}
+        onRetry={canRetry ? handleRetryJoin : undefined}
+      />
     );
   }
 

--- a/www/app/[roomName]/components/LiveKitRoom.tsx
+++ b/www/app/[roomName]/components/LiveKitRoom.tsx
@@ -13,7 +13,8 @@ import {
 import type { components } from "../../reflector-api";
 import { useAuth } from "../../lib/AuthProvider";
 import { useRoomJoinMeeting } from "../../lib/apiHooks";
-import { formatJoinError } from "../../lib/errorUtils";
+import { describeJoinError } from "../../lib/errorUtils";
+import MeetingErrorScreen from "./MeetingErrorScreen";
 import { assertMeetingId } from "../../lib/types";
 import {
   ConsentDialogButton,
@@ -68,6 +69,7 @@ export default function LiveKitRoom({ meeting, room }: LiveKitRoomProps) {
   const joinMutation = useRoomJoinMeeting();
   const [joinedMeeting, setJoinedMeeting] = useState<Meeting | null>(null);
   const [userChoices, setUserChoices] = useState<LocalUserChoices | null>(null);
+  const [joinAttempt, setJoinAttempt] = useState(0);
 
   // ── Consent dialog (same hooks as Daily/Whereby) ──────────
   const { showConsentButton, showRecordingIndicator } = useConsentDialog({
@@ -130,7 +132,12 @@ export default function LiveKitRoom({ meeting, room }: LiveKitRoomProps) {
     return () => {
       cancelled = true;
     };
-  }, [meeting?.id, roomName, authLastUserId, userChoices]);
+  }, [meeting?.id, roomName, authLastUserId, userChoices, joinAttempt]);
+
+  const handleRetryJoin = useCallback(() => {
+    joinMutation.reset();
+    setJoinAttempt((attempt) => attempt + 1);
+  }, [joinMutation]);
 
   const handleDisconnected = useCallback(() => {
     router.push("/browse");
@@ -182,10 +189,14 @@ export default function LiveKitRoom({ meeting, room }: LiveKitRoomProps) {
   }
 
   if (joinMutation.isError) {
+    const { title, message, canRetry } = describeJoinError(joinMutation.error);
     return (
-      <Center h="100vh" bg="gray.50">
-        <Text fontSize="lg">{formatJoinError(joinMutation.error)}</Text>
-      </Center>
+      <MeetingErrorScreen
+        title={title}
+        message={message}
+        roomName={roomName}
+        onRetry={canRetry ? handleRetryJoin : undefined}
+      />
     );
   }
 

--- a/www/app/[roomName]/components/MeetingErrorScreen.tsx
+++ b/www/app/[roomName]/components/MeetingErrorScreen.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Box, Button, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
+
+interface MeetingErrorScreenProps {
+  title: string;
+  message: string;
+  /** Room to go back to, so the user can pick another meeting. */
+  roomName?: string;
+  onRetry?: () => void;
+}
+
+export default function MeetingErrorScreen({
+  title,
+  message,
+  roomName,
+  onRetry,
+}: MeetingErrorScreenProps) {
+  const router = useRouter();
+
+  return (
+    <Flex
+      width="100vw"
+      height="100vh"
+      align="center"
+      justify="center"
+      bg="gray.50"
+      p={4}
+    >
+      <Box
+        width="100%"
+        maxW="480px"
+        bg="white"
+        borderRadius="xl"
+        boxShadow="md"
+        p={{ base: 6, md: 8 }}
+      >
+        <VStack gap={4} align="center" textAlign="center">
+          <Icon as={FaExclamationTriangle} boxSize="40px" color="orange.400" />
+          <Text fontSize="xl" fontWeight="semibold">
+            {title}
+          </Text>
+          <Text color="gray.600" whiteSpace="pre-line">
+            {message}
+          </Text>
+          <VStack gap={2} width="100%" pt={2}>
+            {onRetry && (
+              <Button width="100%" colorPalette="blue" onClick={onRetry}>
+                Try again
+              </Button>
+            )}
+            {roomName && (
+              <Button
+                width="100%"
+                variant="outline"
+                onClick={() => router.push(`/${roomName}`)}
+              >
+                Back to meetings
+              </Button>
+            )}
+            <Button
+              width="100%"
+              variant="ghost"
+              onClick={() => router.push("/browse")}
+            >
+              Go home
+            </Button>
+          </VStack>
+        </VStack>
+      </Box>
+    </Flex>
+  );
+}

--- a/www/app/[roomName]/components/RoomContainer.tsx
+++ b/www/app/[roomName]/components/RoomContainer.tsx
@@ -12,6 +12,7 @@ import {
 import type { components } from "../../reflector-api";
 import MeetingSelection from "../MeetingSelection";
 import useRoomDefaultMeeting from "../useRoomDefaultMeeting";
+import MeetingErrorScreen from "./MeetingErrorScreen";
 import WherebyRoom from "./WherebyRoom";
 import DailyRoom from "./DailyRoom";
 import LiveKitRoom from "./LiveKitRoom";
@@ -128,16 +129,10 @@ export default function RoomContainer(details: RoomDetails) {
 
   if (!room) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        height="100vh"
-        bg="gray.50"
-        p={4}
-      >
-        <Text fontSize="lg">Room not found</Text>
-      </Box>
+      <MeetingErrorScreen
+        title="Room not found"
+        message="This room doesn't exist. Check the link or ask the organizer for a new one."
+      />
     );
   }
 
@@ -157,20 +152,12 @@ export default function RoomContainer(details: RoomDetails) {
 
   if (errors.length > 0) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        height="100vh"
-        bg="gray.50"
-        p={4}
-      >
-        {errors.map((error, i) => (
-          <Text key={i} fontSize="lg">
-            {printApiError(error)}
-          </Text>
-        ))}
-      </Box>
+      <MeetingErrorScreen
+        title="We couldn't open this meeting"
+        message={errors.map(printApiError).join("\n")}
+        roomName={roomName}
+        onRetry={() => router.refresh()}
+      />
     );
   }
 

--- a/www/app/lib/__tests__/errorUtils.test.ts
+++ b/www/app/lib/__tests__/errorUtils.test.ts
@@ -1,0 +1,45 @@
+import { describeJoinError, formatJoinError } from "../errorUtils";
+
+describe("describeJoinError", () => {
+  it("describes a meeting that has ended and offers a retry", () => {
+    const result = describeJoinError({ detail: "Meeting has ended" });
+    expect(result.title).toBe("This meeting has ended");
+    expect(result.canRetry).toBe(true);
+  });
+
+  it("reads the detail from a nested API response", () => {
+    const result = describeJoinError({
+      response: { data: { detail: "Meeting is not active" } },
+    });
+    expect(result.title).toBe("This meeting is no longer active");
+  });
+
+  it("does not offer a retry for errors a retry cannot fix", () => {
+    expect(describeJoinError({ detail: "Meeting not found" }).canRetry).toBe(
+      false,
+    );
+    expect(describeJoinError({ detail: "Room not found" }).canRetry).toBe(
+      false,
+    );
+  });
+
+  it("keeps the unknown detail as the message", () => {
+    const result = describeJoinError({ detail: "Something exploded" });
+    expect(result.title).toBe("We couldn't join the meeting");
+    expect(result.message).toBe("Something exploded");
+  });
+
+  it("falls back when there is no detail at all", () => {
+    const result = describeJoinError(null);
+    expect(result.title).toBe("We couldn't join the meeting");
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatJoinError", () => {
+  it("renders a single sentence for inline banners", () => {
+    expect(formatJoinError({ detail: "Meeting has ended" })).toBe(
+      "This meeting has ended. The organizer can start a new one.",
+    );
+  });
+});

--- a/www/app/lib/errorUtils.ts
+++ b/www/app/lib/errorUtils.ts
@@ -14,20 +14,52 @@ export function getErrorDetail(error: unknown, fallback: string): string {
   return fallback;
 }
 
-export function formatJoinError(error: unknown): string {
+export type JoinErrorDescription = {
+  title: string;
+  message: string;
+  canRetry: boolean;
+};
+
+export function describeJoinError(error: unknown): JoinErrorDescription {
   const detail = getErrorDetail(error, "");
   switch (detail) {
     case "Meeting has ended":
-      return "This meeting has ended. The organizer can start a new one.";
+      return {
+        title: "This meeting has ended",
+        message: "The organizer can start a new one.",
+        canRetry: true,
+      };
     case "Meeting is not active":
-      return "This meeting is no longer active. Ask the organizer to start it again.";
+      return {
+        title: "This meeting is no longer active",
+        message: "Ask the organizer to start it again.",
+        canRetry: true,
+      };
     case "Meeting not found":
-      return "This meeting no longer exists. Check the link or ask the organizer for a new one.";
+      return {
+        title: "Meeting not found",
+        message:
+          "This meeting no longer exists. Check the link or ask the organizer for a new one.",
+        canRetry: false,
+      };
     case "Room not found":
-      return "This room doesn't exist.";
+      return {
+        title: "Room not found",
+        message: "This room doesn't exist.",
+        canRetry: false,
+      };
     default:
-      return detail || "We couldn't join the meeting. Please try again.";
+      return {
+        title: "We couldn't join the meeting",
+        message: detail || "Something went wrong on the way in.",
+        canRetry: true,
+      };
   }
+}
+
+export function formatJoinError(error: unknown): string {
+  const { title, message } = describeJoinError(error);
+  return `${title}. ${message}`;
 }
 
 export function shouldShowError(error: Error | null | undefined) {


### PR DESCRIPTION
**Summary**

Meetings were created with a fixed `end_date` (start + 8h) that nothing ever moved, so a meeting running past that window stayed active but every rejoin was refused with `400 "Meeting has ended"`, and the meeting vanished from the active-meeting lists. `process_meetings` now extends the lease (end_date → now + 8h) when a meeting has active sessions and less than 4h left, and propagates the new expiry to the platform via a new `extend_meeting_expiration` hook; a no-op for Whereby/LiveKit, implemented for Daily, where the room's own `exp` would otherwise keep rejecting joins. Supporting change: `DailyApiClient.update_room`, sending only explicitly-set properties so an update can't reset `enable_knocking` or the recording config.

The join failure screen was also a single line of red text on a blank page. It's now a card with a title, an explanation, a retry that re-issues the join in place, and navigation shared by `DailyRoom`, `LiveKitRoom`, and `RoomContainer`.

**Testing**

8 new backend tests (`server/tests/test_meeting_extension.py`), including a regression test that joins a meeting whose `end_date` is already past while its sessions are open; verified they fail without the fix. Full backend suite: 692 passed (one unrelated flaky WebRTC test, `test_transcripts_rtc_ws.py`, passes in isolation). Frontend: `tsc --noEmit` clean, jest 12/12, `next build` succeeds.