### PR TITLE
fix(www): copy pnpm-workspace.yaml into Docker deps stage

### DIFF
--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY --link package.json pnpm-lock.yaml* ./
+COPY --link package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed


### PR DESCRIPTION
## Summary

The frontend `build-and-push` Docker build fails on `pnpm install --frozen-lockfile` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

#973 moved the security overrides from `package.json`'s `pnpm` field into `pnpm-workspace.yaml`, but the Dockerfile deps stage only copied `package.json` and `pnpm-lock.yaml`. Inside the container pnpm saw no overrides while the lockfile recorded six, so the frozen install refused to proceed.

Fix: include `pnpm-workspace.yaml*` in the deps stage COPY. The builder stage already copies the full context.