### PR TITLE
fix(www): approve dependency build scripts for pnpm 11

### DIFF
--- a/www/pnpm-workspace.yaml
+++ b/www/pnpm-workspace.yaml
@@ -4,6 +4,15 @@
 #
 # Requires pnpm >= 10. pnpm 8 fails on this file with
 # ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION.
+# pnpm 11 fails the install on unapproved dependency build scripts
+# (ERR_PNPM_IGNORED_BUILDS). allowBuilds replaces the pnpm 10
+# onlyBuiltDependencies list. Approve the ones we rely on.
+allowBuilds:
+  "@parcel/watcher": true
+  "@sentry/cli": true
+  sharp: true
+  unrs-resolver: true
+
 overrides:
   "minimatch@>=5.0.0 <5.1.8": "5.1.8"
   "js-yaml@<4.1.1": "4.1.1"


### PR DESCRIPTION
## Summary

The frontend Docker build still fails after #975, now with `ERR_PNPM_IGNORED_BUILDS`. pnpm 11 turned unapproved dependency build scripts from a warning into a hard install failure, and the Dockerfile uses corepack with no pnpm version pin, so it downloads the latest pnpm (11.23.0).

This approves the four packages with install scripts (`@parcel/watcher`, `@sentry/cli`, `sharp`, `unrs-resolver`) via the `allowBuilds` map in `pnpm-workspace.yaml`, which replaces the pnpm 10 `onlyBuiltDependencies` list.

## Verification

- `docker build --target deps www/` reproduced the CI failure on main and passes with this change.
- Full `docker build www/` completes through `pnpm build-production`.
- `pnpm install --frozen-lockfile` still works with local pnpm 11.3.0.

https://claude.ai/code/session_01Max4fFZx5LkH4fFubPzHDZ